### PR TITLE
Harden EULA compliance flow with version re-accept enforcement

### DIFF
--- a/docs/development-checklist.md
+++ b/docs/development-checklist.md
@@ -19,7 +19,7 @@ Legend:
 - [x] Transparent OBS-ready overlay window
 - [x] Persistent simulation watermark at ~20% opacity
 - [x] Low-friction control center (provider endpoint controls + keychain key save + status refresh completed)
-- [~] EULA gate before start (start blocked until accepted)
+- [x] EULA gate before start (start blocked until accepted + version-change re-accept enforcement)
 
 ### Safety + Compliance
 - [x] Local synchronous pre-render safety filter
@@ -143,8 +143,8 @@ Legend:
   - Status: Real signal weighting now drives donation/TTS realism and pacing behavior.
 
 ### Milestone 3 — Onboarding, Hardening, Compliance
-- [~] Tiering + one-click orchestrator + robust fallback + polished compliance gate
-  - Status: Core implementation complete; production acceptance evidence (onboarding UX checks, compliance-loop failure states, release checklist automation) now tracked explicitly below.
+- [x] Tiering + one-click orchestrator + robust fallback + polished compliance gate
+  - Status: Completed with enforced EULA re-accept flow on version changes plus production acceptance evidence tracked below.
 
 
 ## 9) Production Acceptance Evidence (Milestone 3 closure criteria)

--- a/src/server.ts
+++ b/src/server.ts
@@ -12,6 +12,7 @@ import { SecretStore } from "./security/secretStore.js";
 import { collectHardwareProfile, recommendTier } from "./services/bootDiagnostics.js";
 import { ComplianceLogger } from "./services/complianceLogger.js";
 import { runReadinessChecks } from "./services/readinessChecks.js";
+import { reconcileComplianceUpdate } from "./services/complianceGate.js";
 import { SimulationOrchestrator } from "./services/simulationOrchestrator.js";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -65,14 +66,33 @@ app.get("/api/events", (req, res) => {
 });
 
 app.post("/api/config", (req, res) => {
-  const previousAccepted = config.compliance.eulaAccepted;
-  config = mergeConfig(config, req.body);
+  const previousCompliance = { ...config.compliance };
+  const mergedConfig = mergeConfig(config, req.body);
+  const complianceUpdate = reconcileComplianceUpdate(previousCompliance, mergedConfig.compliance);
+  config = {
+    ...mergedConfig,
+    compliance: complianceUpdate.compliance
+  };
   configStore.save(config);
 
-  if (!previousAccepted && config.compliance.eulaAccepted) {
-    complianceLogger.logEulaAcceptance(config.compliance.eulaVersion);
-    onboardingComplete = true;
+  if (complianceUpdate.versionChanged) {
+    complianceLogger.logEvent("eula_version_changed", {
+      from: previousCompliance.eulaVersion,
+      to: complianceUpdate.compliance.eulaVersion
+    });
   }
+
+  if (complianceUpdate.acceptanceInvalidated) {
+    complianceLogger.logEvent("eula_reaccept_required", {
+      version: complianceUpdate.compliance.eulaVersion
+    });
+  }
+
+  if (complianceUpdate.acceptanceRecorded) {
+    complianceLogger.logEulaAcceptance(config.compliance.eulaVersion);
+  }
+
+  onboardingComplete = config.compliance.eulaAccepted;
 
   void refreshBootAndReadiness();
   res.json({ ok: true, config, onboardingComplete });

--- a/src/services/complianceGate.ts
+++ b/src/services/complianceGate.ts
@@ -1,0 +1,27 @@
+import { ComplianceConfig } from "../core/types.js";
+
+export interface ComplianceReconcileResult {
+  compliance: ComplianceConfig;
+  versionChanged: boolean;
+  acceptanceRecorded: boolean;
+  acceptanceInvalidated: boolean;
+}
+
+export function reconcileComplianceUpdate(previous: ComplianceConfig, next: ComplianceConfig): ComplianceReconcileResult {
+  const versionChanged = previous.eulaVersion !== next.eulaVersion;
+  const acceptanceInvalidated = versionChanged && previous.eulaAccepted && next.eulaAccepted;
+
+  const compliance: ComplianceConfig = {
+    eulaVersion: next.eulaVersion,
+    eulaAccepted: acceptanceInvalidated ? false : next.eulaAccepted
+  };
+
+  const acceptanceRecorded = !previous.eulaAccepted && compliance.eulaAccepted;
+
+  return {
+    compliance,
+    versionChanged,
+    acceptanceRecorded,
+    acceptanceInvalidated
+  };
+}

--- a/tests/complianceGate.test.ts
+++ b/tests/complianceGate.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { reconcileComplianceUpdate } from "../src/services/complianceGate.js";
+
+describe("compliance gate reconciliation", () => {
+  it("records acceptance when first accepted", () => {
+    const result = reconcileComplianceUpdate(
+      { eulaAccepted: false, eulaVersion: "2026-01" },
+      { eulaAccepted: true, eulaVersion: "2026-01" }
+    );
+
+    expect(result.compliance.eulaAccepted).toBe(true);
+    expect(result.acceptanceRecorded).toBe(true);
+    expect(result.versionChanged).toBe(false);
+    expect(result.acceptanceInvalidated).toBe(false);
+  });
+
+  it("invalidates acceptance when EULA version changes", () => {
+    const result = reconcileComplianceUpdate(
+      { eulaAccepted: true, eulaVersion: "2026-01" },
+      { eulaAccepted: true, eulaVersion: "2026-02" }
+    );
+
+    expect(result.versionChanged).toBe(true);
+    expect(result.acceptanceInvalidated).toBe(true);
+    expect(result.compliance.eulaAccepted).toBe(false);
+    expect(result.acceptanceRecorded).toBe(false);
+  });
+});


### PR DESCRIPTION
### Motivation
- Close a remaining checklist gap by making the EULA gate deterministic when the EULA text/version changes so stale acceptances cannot carry forward. 
- Ensure compliance lifecycle events are auditable and surfaceable (version changes and re-accept required) to support onboarding and legal traceability.

### Description
- Added a compliance reconciliation helper `reconcileComplianceUpdate` in `src/services/complianceGate.ts` to detect EULA version changes, invalidate prior acceptance when necessary, and surface a compact reconciliation result. 
- Wired reconciliation into the configuration update path in `src/server.ts` so `/api/config` now applies the reconciliation, logs `eula_version_changed` and `eula_reaccept_required` events, and continues to log fresh acceptances via `ComplianceLogger.logEulaAcceptance`. 
- Kept onboarding state tied to the active `config.compliance.eulaAccepted` value so start flows remain blocked until a valid acceptance exists. 
- Added unit tests `tests/complianceGate.test.ts` covering first-time acceptance and invalidation-on-version-bump, and updated `docs/development-checklist.md` to reflect the resolved checklist items. 

### Testing
- Ran the test suite with `npm test` (Vitest) and all tests passed, including the new `tests/complianceGate.test.ts`. 
- Built the project with `npm run build` (TypeScript compile) and the build completed successfully. 
- Validated release checklist automation with `npm run ci:release-checklist` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b501d8ee7083269eedc5fd1b9e79ed)