### PR TITLE
Add status banner and centralized action handler; refactor control panel UI and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,13 @@
-# StreamSim: The AI-Powered Gym for Content Creators. 🎙️🚀
+# StreamSim
 
-Never stream to 0 viewers again. StreamSim generates a hyper-realistic, real-time simulated audience that hears your voice, sees your camera, and reacts to your energy. Built for aspiring streamers and VOD creators who want to master "dead air," practice crowd control, and build on-camera charisma before going live.
+StreamSim is a local-first simulation control center for testing creator workflows with a synthetic audience stream.
 
-## What this repository contains
-- Product/architecture specification: [`docs/technical-spec.md`](docs/technical-spec.md)
-- Development checklist: [`docs/development-checklist.md`](docs/development-checklist.md)
-- Working MVP application scaffold implementing core simulation logic + dashboard/overlay preview
-
-## Implemented in this milestone
-- **Spooling Engine** with engagement-decay math, jitter, energy scaling, and Slow Mode override.
-- **Safety pre-render filter** that drops disallowed text.
-- **AudioStateManager** for TTS/mic mutual exclusion behavior.
-- **Simulation orchestrator** that binds config + tone sampling + mock audience generation.
-- **Control Center + Overlay preview UI** (dark themed) with immutable watermark.
-- **SSE event stream API** for near-real-time overlay updates.
+## Repository purpose
+This repository contains:
+- The StreamSim service and web control center/overlay preview.
+- Simulation pipeline components (capture, context assembly, inference adapters, safety filtering, and message spooling).
+- Reliability/compliance/security hardening utilities and checks.
+- Product and engineering documentation.
 
 ## Quick start
 ```bash
@@ -21,7 +15,33 @@ npm install
 npm run dev
 ```
 
-Then open `http://localhost:4173`.
+Open `http://localhost:4173`.
 
-## Vision
-StreamSim simulates realistic audience behavior (chat, reactions, donation/TTS events) from multimodal context (voice/tone + periodic vision tags), while enforcing local pre-render safety constraints and a compliance-oriented simulation watermark.
+## Scripts
+- `npm run dev` — start the development server.
+- `npm run build` — compile TypeScript to `dist/`.
+- `npm test` — run the Vitest suite.
+- `npm run ci:slo` — run SLO checks.
+- `npm run ci:trace-gate` — run trace-gate checks against the realistic trace artifact.
+- `npm run ci:release-checklist` — execute production release checklist assertions.
+- `npm run ci:capture-traces` — capture reproducible NFR traces.
+
+## Project layout
+- `src/server.ts` — API + SSE entry point.
+- `src/public/` — control center and overlay web UI.
+- `src/services/` — orchestration, readiness, observability, compliance, and resilience services.
+- `src/pipeline/` — context, prompt, and output parsing pipeline layers.
+- `src/llm/` — inference providers and realism tuning.
+- `src/capture/` — STT and vision capture integrations.
+- `src/security/` — banlist/diagnostics/secret-store utilities.
+- `src/config/` — runtime config schema, persistence, and migrations.
+- `tests/` — integration and unit coverage.
+- `docs/` — product specification and development checklist.
+
+## Documentation
+- Technical specification: [`docs/technical-spec.md`](docs/technical-spec.md)
+- Development checklist: [`docs/development-checklist.md`](docs/development-checklist.md)
+- Docs index: [`docs/README.md`](docs/README.md)
+
+## Current status
+The repository is an actively developed MVP with production-hardening checks in place (readiness checks, compliance gating, reliability tests, and NFR trace validation).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,10 @@
+# StreamSim Docs Index
+
+## Core docs
+- [`technical-spec.md`](./technical-spec.md): product vision, architecture intent, requirements, and milestone framing.
+- [`development-checklist.md`](./development-checklist.md): implementation tracking checklist mapped to features, hardening items, and acceptance evidence.
+
+## How to use these docs
+- Start with the technical spec for context and scope.
+- Use the development checklist to verify implementation coverage and release readiness.
+- Keep implementation evidence references current when adding or modifying major capabilities.

--- a/docs/technical-spec.md
+++ b/docs/technical-spec.md
@@ -1,4 +1,4 @@
-# StreamSim Technical Specification (Working Title)
+# StreamSim Technical Specification
 
 ## 1. Executive Summary & Product Vision
 

--- a/src/public/app.js
+++ b/src/public/app.js
@@ -3,6 +3,7 @@ const metaEl = document.getElementById("meta");
 const wizardBackdrop = document.getElementById("wizardBackdrop");
 const readinessList = document.getElementById("readinessList");
 const diagnosticsSummary = document.getElementById("diagnosticsSummary");
+const statusBanner = document.getElementById("statusBanner");
 
 const controls = {
   viewerCount: document.getElementById("viewerCount"),
@@ -32,6 +33,34 @@ const controls = {
   overrideReason: document.getElementById("overrideReason"),
   eulaAccepted: document.getElementById("eulaAccepted")
 };
+
+function setStatus(message, tone = "success") {
+  statusBanner.textContent = message;
+  statusBanner.classList.remove("success", "warn", "error");
+  statusBanner.classList.add(tone);
+}
+
+function setPending(button, isPending) {
+  if (!button) return;
+  button.disabled = isPending;
+}
+
+async function runAction({ button, pendingText, successText, onRun }) {
+  try {
+    setPending(button, true);
+    if (pendingText) setStatus(pendingText, "warn");
+    const result = await onRun();
+    if (successText) setStatus(successText, "success");
+    return result;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    setStatus(message, "error");
+    metaEl.textContent = message;
+    return undefined;
+  } finally {
+    setPending(button, false);
+  }
+}
 
 function getPayload() {
   return {
@@ -137,62 +166,137 @@ async function post(url, body = undefined) {
   return response.json().catch(() => ({}));
 }
 
-document.getElementById("save").addEventListener("click", async () => {
-  const result = await post("/api/config", getPayload());
-  hydrateControls(result.config);
+const saveBtn = document.getElementById("save");
+const startBtn = document.getElementById("start");
+const stopBtn = document.getElementById("stop");
+const rebindBtn = document.getElementById("rebindAudio");
+const sidecarCancelBtn = document.getElementById("sidecarCancel");
+const sidecarResumeBtn = document.getElementById("sidecarResume");
+const runReadinessBtn = document.getElementById("runReadiness");
+const saveCloudKeyBtn = document.getElementById("saveCloudKey");
+const refreshStatusBtn = document.getElementById("refreshStatus");
+const applyOverrideBtn = document.getElementById("applyOverride");
+const completeWizardBtn = document.getElementById("completeWizard");
+
+saveBtn.addEventListener("click", async () => {
+  const result = await runAction({
+    button: saveBtn,
+    pendingText: "Saving config...",
+    successText: "Config saved.",
+    onRun: () => post("/api/config", getPayload())
+  });
+  if (result?.config) hydrateControls(result.config);
 });
 
-document.getElementById("start").addEventListener("click", async () => {
-  try {
-    await post("/api/start");
-  } catch (error) {
-    metaEl.textContent = `Start blocked: ${error.message}`;
-  }
+startBtn.addEventListener("click", async () => {
+  await runAction({
+    button: startBtn,
+    pendingText: "Starting simulation...",
+    successText: "Simulation started.",
+    onRun: () => post("/api/start")
+  });
 });
 
-document.getElementById("stop").addEventListener("click", async () => post("/api/stop"));
-document.getElementById("rebindAudio").addEventListener("click", async () => post("/api/audio/rebind"));
-document.getElementById("sidecarCancel").addEventListener("click", async () => post("/api/sidecar/cancel"));
-document.getElementById("sidecarResume").addEventListener("click", async () => post("/api/sidecar/resume"));
-document.getElementById("runReadiness").addEventListener("click", async () => {
-  const response = await fetch("/api/onboarding/readiness");
-  const payload = await response.json();
-  renderReadiness(payload.readiness);
+stopBtn.addEventListener("click", async () => {
+  await runAction({
+    button: stopBtn,
+    pendingText: "Stopping simulation...",
+    successText: "Simulation stopped.",
+    onRun: () => post("/api/stop")
+  });
 });
-document.getElementById("saveCloudKey").addEventListener("click", async () => {
-  try {
-    await post("/api/secrets/cloud-key", { key: controls.cloudApiKey.value });
-    metaEl.textContent = "Cloud API key saved to keychain.";
-    controls.cloudApiKey.value = "";
-  } catch (error) {
-    metaEl.textContent = `Cloud key save failed: ${error.message}`;
-  }
+
+rebindBtn.addEventListener("click", async () => {
+  await runAction({
+    button: rebindBtn,
+    pendingText: "Rebinding audio...",
+    successText: "Audio rebind requested.",
+    onRun: () => post("/api/audio/rebind")
+  });
 });
-document.getElementById("refreshStatus").addEventListener("click", async () => {
-  const response = await fetch("/api/status");
-  const payload = await response.json();
+
+sidecarCancelBtn.addEventListener("click", async () => {
+  await runAction({
+    button: sidecarCancelBtn,
+    pendingText: "Cancelling sidecar pull...",
+    successText: "Sidecar pull cancellation requested.",
+    onRun: () => post("/api/sidecar/cancel")
+  });
+});
+
+sidecarResumeBtn.addEventListener("click", async () => {
+  await runAction({
+    button: sidecarResumeBtn,
+    pendingText: "Resuming sidecar pull...",
+    successText: "Sidecar pull resume requested.",
+    onRun: () => post("/api/sidecar/resume")
+  });
+});
+
+runReadinessBtn.addEventListener("click", async () => {
+  const payload = await runAction({
+    button: runReadinessBtn,
+    pendingText: "Running readiness checks...",
+    successText: "Readiness refreshed.",
+    onRun: async () => {
+      const response = await fetch("/api/onboarding/readiness");
+      if (!response.ok) throw new Error(`Readiness request failed (${response.status})`);
+      return response.json();
+    }
+  });
+  if (payload?.readiness) renderReadiness(payload.readiness);
+});
+
+saveCloudKeyBtn.addEventListener("click", async () => {
+  await runAction({
+    button: saveCloudKeyBtn,
+    pendingText: "Saving cloud API key...",
+    successText: "Cloud API key saved to keychain.",
+    onRun: () => post("/api/secrets/cloud-key", { key: controls.cloudApiKey.value })
+  });
+  controls.cloudApiKey.value = "";
+});
+
+refreshStatusBtn.addEventListener("click", async () => {
+  const payload = await runAction({
+    button: refreshStatusBtn,
+    pendingText: "Refreshing status...",
+    successText: "Status refreshed.",
+    onRun: async () => {
+      const response = await fetch("/api/status");
+      if (!response.ok) throw new Error(`Status request failed (${response.status})`);
+      return response.json();
+    }
+  });
+  if (!payload) return;
   renderReadiness(payload.readiness);
   renderDiagnostics(payload);
   hydrateControls(payload.config);
 });
-document.getElementById("applyOverride").addEventListener("click", async () => {
-  try {
-    await post("/api/security/override-localhost", {
-      allow: controls.allowNonLocalSidecarOverride.checked,
-      reason: controls.overrideReason.value
-    });
-  } catch (error) {
-    metaEl.textContent = `Override failed: ${error.message}`;
-  }
+
+applyOverrideBtn.addEventListener("click", async () => {
+  await runAction({
+    button: applyOverrideBtn,
+    pendingText: "Applying override...",
+    successText: "Override updated.",
+    onRun: () =>
+      post("/api/security/override-localhost", {
+        allow: controls.allowNonLocalSidecarOverride.checked,
+        reason: controls.overrideReason.value
+      })
+  });
 });
-document.getElementById("completeWizard").addEventListener("click", async () => {
-  try {
-    const payload = await post("/api/onboarding/complete");
-    renderReadiness(payload.readiness);
-    wizardBackdrop.classList.add("hidden");
-  } catch (error) {
-    metaEl.textContent = `Onboarding blocked: ${error.message}`;
-  }
+
+completeWizardBtn.addEventListener("click", async () => {
+  const payload = await runAction({
+    button: completeWizardBtn,
+    pendingText: "Completing onboarding...",
+    successText: "Onboarding complete.",
+    onRun: () => post("/api/onboarding/complete")
+  });
+  if (!payload?.readiness) return;
+  renderReadiness(payload.readiness);
+  wizardBackdrop.classList.add("hidden");
 });
 
 const events = new EventSource("/api/events");
@@ -201,8 +305,23 @@ events.addEventListener("messages", (event) => {
   messages.forEach((msg) => {
     const item = document.createElement("div");
     item.className = "chat-msg";
-    const donation = msg.donationCents ? `<span class="donation">$${msg.donationCents / 100}</span>` : "";
-    item.innerHTML = `<span class="user">${msg.username}</span>${msg.text || msg.emotes.join(" ")}${donation}`;
+
+    const user = document.createElement("span");
+    user.className = "user";
+    user.textContent = msg.username;
+
+    const messageText = document.createElement("span");
+    messageText.textContent = msg.text || msg.emotes.join(" ");
+
+    item.append(user, messageText);
+
+    if (msg.donationCents) {
+      const donation = document.createElement("span");
+      donation.className = "donation";
+      donation.textContent = `$${(msg.donationCents / 100).toFixed(2)}`;
+      item.append(donation);
+    }
+
     chatEl.prepend(item);
     while (chatEl.children.length > 22) chatEl.lastChild.remove();
   });

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -67,7 +67,7 @@
         </div>
         <div class="buttons">
           <button id="save">Save Config</button>
-          <button id="start">Start Simulation</button>
+          <button id="start" class="primary">Start Simulation</button>
           <button id="stop">Stop</button>
           <button id="rebindAudio">Rebind Audio</button>
           <button id="sidecarCancel">Cancel Sidecar Pull</button>
@@ -77,6 +77,7 @@
           <button id="saveCloudKey">Save Cloud Key</button>
           <button id="refreshStatus">Refresh Status</button>
         </div>
+        <p id="statusBanner" class="status-banner" aria-live="polite">Ready.</p>
         <pre id="diagnosticsSummary"></pre>
         <ul id="readinessList"></ul>
         <pre id="meta"></pre>

--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -5,6 +5,9 @@
   --panel-alt: rgba(0, 0, 0, 0.3);
   --text: #e9edf3;
   --accent: #4ade80;
+  --accent-muted: rgba(74, 222, 128, 0.2);
+  --warning: #fbbf24;
+  --danger: #fb7185;
 }
 
 * { box-sizing: border-box; font-family: Inter, ui-sans-serif, system-ui; }
@@ -14,14 +17,20 @@ body { margin: 0; background: radial-gradient(circle at top, #161925, var(--bg))
 .grid { display: grid; grid-template-columns: 1fr; gap: 12px; max-height: 70vh; overflow: auto; padding-right: 6px; }
 label { display: flex; flex-direction: column; gap: 6px; font-size: 0.9rem; }
 input, select, button { border-radius: 8px; border: 1px solid #3f475f; background: #12141c; color: var(--text); padding: 8px 10px; }
+input:focus-visible, select:focus-visible, button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
 .buttons { display: flex; gap: 8px; margin-top: 14px; flex-wrap: wrap; }
-button { cursor: pointer; }
+button { cursor: pointer; transition: border-color 140ms ease, background-color 140ms ease, opacity 140ms ease; }
 button:hover { border-color: var(--accent); }
+button:disabled { opacity: 0.6; cursor: progress; }
+button.primary { background: var(--accent-muted); border-color: #58c77d; }
 .overlay { position: relative; background: transparent; border-style: dashed; backdrop-filter: blur(1px); }
 .transparent-ready { box-shadow: inset 0 0 0 1px rgba(125, 211, 252, 0.3); }
 .watermark { position: absolute; top: 10px; right: 10px; opacity: 0.2; font-weight: 800; letter-spacing: 0.05em; }
 #chat { display: flex; flex-direction: column; gap: 8px; margin-top: 12px; }
-.chat-msg { background: var(--panel-alt); border: 1px solid #30384b; padding: 8px 10px; border-radius: 10px; }
+.chat-msg { background: var(--panel-alt); border: 1px solid #30384b; padding: 8px 10px; border-radius: 10px; line-height: 1.4; }
 .user { color: #7dd3fc; font-weight: 700; margin-right: 8px; }
 .donation { color: #facc15; margin-left: 8px; }
 pre { margin-top: 12px; background: #0c0e14; border: 1px solid #293145; border-radius: 8px; padding: 10px; font-size: 0.78rem; min-height: 130px; }
@@ -33,3 +42,24 @@ pre { margin-top: 12px; background: #0c0e14; border: 1px solid #293145; border-r
 
 #readinessList { margin-top: 10px; padding-left: 18px; }
 #readinessList li { margin-bottom: 6px; }
+.status-banner {
+  margin: 12px 0 0;
+  padding: 8px 10px;
+  border-radius: 8px;
+  border: 1px solid #334155;
+  background: #0f172a;
+  font-size: 0.85rem;
+}
+.status-banner.success { border-color: #2f855a; color: #9ae6b4; }
+.status-banner.warn { border-color: #a16207; color: #fde68a; }
+.status-banner.error { border-color: #be123c; color: #fecdd3; }
+
+@media (max-width: 1080px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+
+  .grid {
+    max-height: none;
+  }
+}


### PR DESCRIPTION
### Motivation
- Improve user feedback and UX for control actions by surfacing operation state and results in a dedicated status banner. 
- Reduce duplicated async/error handling in the control panel by centralizing common behavior for button-driven API calls. 
- Clarify repository purpose and developer workflows in the top-level docs and add a docs index for easier onboarding. 

### Description
- Introduced a `statusBanner` UI element and `setStatus`, `setPending`, and `runAction` helpers in `src/public/app.js` to centralize async button handling and consistent status messages. 
- Reworked control panel event handlers to use `runAction` for `save`, `start`, `stop`, `rebindAudio`, `sidecarCancel`, `sidecarResume`, `runReadiness`, `saveCloudKey`, `refreshStatus`, `applyOverride`, and `completeWizard`, and added element lookups for those buttons. 
- Improved SSE message rendering to build DOM nodes safely (separating username, message text, and formatted donation amount) and capped chat length client-side. 
- Updated `src/public/index.html` to add a `statusBanner` element and mark the `start` button as primary, and updated `src/public/styles.css` with focus states, button/pending styles, `status-banner` color variants, responsive layout tweaks, and other visual refinements. 
- Overhauled `README.md` to clarify repository purpose, added `docs/README.md` as a docs index, and made minor edits to `docs/technical-spec.md` to refine titles and descriptions. 

### Testing
- Ran the unit/integration test suite with `npm test` (Vitest) and the tests passed. 
- Performed a quick automated status API smoke call via the updated `runAction` flow during development; no errors were reported by the client-side handlers.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b50394a75c832683d555b1a370568e)