### PR TITLE
Gate live monitor on combined mic+camera verification and surface inference source tags

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -92,6 +92,8 @@ export interface PromptPayload {
   providerConditioning: ProviderConditioning;
 }
 
+export type MessageSource = "real-inference" | "mock-inference" | "mock-audience" | "fallback-mock" | "unknown";
+
 export interface ChatMessage {
   id: string;
   username: string;
@@ -100,6 +102,7 @@ export interface ChatMessage {
   donationCents?: number;
   ttsText?: string;
   createdAt: string;
+  source?: MessageSource;
 }
 
 export interface QueueMessage {

--- a/src/llm/mockAudienceGenerator.ts
+++ b/src/llm/mockAudienceGenerator.ts
@@ -74,7 +74,8 @@ export function generateAudienceBatch(config: SimulationConfig, tone: ToneSnapsh
       username: `viewer_${Math.floor(Math.random() * 9999)}`,
       text: withBias(text, config.bias === "split" && features.personaBiasScore < 0.45 ? "disagree" : config.bias, conditioning, personaCalibration.contrarianism),
       emotes: Math.random() > 0.45 ? [pick(emotePool)] : [],
-      createdAt: new Date().toISOString()
+      createdAt: new Date().toISOString(),
+      source: "mock-audience"
     };
 
     Object.assign(message, realisticDonation(config, tone, conditioning, safeContext));

--- a/src/pipeline/outputParser.ts
+++ b/src/pipeline/outputParser.ts
@@ -18,7 +18,15 @@ function coerceMessage(raw: unknown): ChatMessage | null {
     emotes: candidate.emotes,
     createdAt: typeof candidate.createdAt === "string" ? candidate.createdAt : new Date().toISOString(),
     donationCents: typeof candidate.donationCents === "number" ? candidate.donationCents : undefined,
-    ttsText: typeof candidate.ttsText === "string" ? candidate.ttsText : undefined
+    ttsText: typeof candidate.ttsText === "string" ? candidate.ttsText : undefined,
+    source:
+      candidate.source === "real-inference" ||
+      candidate.source === "mock-inference" ||
+      candidate.source === "mock-audience" ||
+      candidate.source === "fallback-mock" ||
+      candidate.source === "unknown"
+        ? candidate.source
+        : undefined
   };
 }
 

--- a/src/public/app.js
+++ b/src/public/app.js
@@ -382,6 +382,22 @@ function renderDeviceChecks(result) {
   });
 }
 
+function updateMonitorAvailability(verification) {
+  const monitorReady = Boolean(verification?.micPermission && verification?.cameraPermission && verification?.hasMicDevice && verification?.hasCameraDevice);
+  if (liveMonitorEnabled) {
+    liveMonitorEnabled.disabled = !monitorReady;
+  }
+
+  if (!monitorReady) {
+    if (liveMonitorEnabled?.checked) liveMonitorEnabled.checked = false;
+    stopLiveMonitor();
+    setLiveMonitorStatus("Live monitor requires both mic and camera grants plus detected devices.", "warn");
+    return;
+  }
+
+  setLiveMonitorStatus("Live monitor ready. Toggle enable to start live camera + voice meter.", "ok");
+}
+
 async function verifyLocalDevices() {
   if (!navigator.mediaDevices?.enumerateDevices) {
     throw new Error("Browser does not support media device enumeration.");
@@ -567,7 +583,9 @@ verifyDevicesBtn.addEventListener("click", async () => {
     successText: "Device verification complete.",
     onRun: () => verifyLocalDevices()
   });
-  if (verification) renderDeviceChecks(verification);
+  if (!verification) return;
+  renderDeviceChecks(verification);
+  updateMonitorAvailability(verification);
 });
 
 openOverlayWindowBtn.addEventListener("click", () => {
@@ -661,6 +679,11 @@ events.addEventListener("messages", (event) => {
 
     item.append(user, messageText);
 
+    const source = document.createElement("span");
+    source.className = "source-tag";
+    source.textContent = msg.source ?? "unknown";
+    item.append(source);
+
     if (msg.donationCents) {
       const donation = document.createElement("span");
       donation.className = "donation";
@@ -697,6 +720,11 @@ async function boot() {
   summarizeAiHealth(payload);
   summarizeTtsHealth(payload);
   summarizeSttHealth(payload);
+  if (liveMonitorEnabled) {
+    liveMonitorEnabled.checked = false;
+    liveMonitorEnabled.disabled = true;
+  }
+  setLiveMonitorStatus("Run Verify Mic/Camera to enable the live monitor.", "warn");
 }
 
 void boot();

--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -35,6 +35,17 @@ button.primary { background: var(--accent-muted); border-color: #58c77d; }
 .chat-msg { background: var(--panel-alt); border: 1px solid #30384b; padding: 8px 10px; border-radius: 10px; line-height: 1.4; }
 .user { color: #7dd3fc; font-weight: 700; margin-right: 8px; }
 .donation { color: #facc15; margin-left: 8px; }
+
+.source-tag {
+  margin-left: 8px;
+  padding: 1px 6px;
+  border: 1px solid #334155;
+  border-radius: 999px;
+  font-size: 0.68rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #cbd5e1;
+}
 pre { margin-top: 12px; background: #0c0e14; border: 1px solid #293145; border-radius: 8px; padding: 10px; font-size: 0.78rem; min-height: 130px; }
 
 .onboarding-panel {

--- a/src/services/simulationOrchestrator.ts
+++ b/src/services/simulationOrchestrator.ts
@@ -81,20 +81,9 @@ export class SimulationOrchestrator {
     return { ...this.aiStatus };
   }
 
-  private setAiStatus(patch: Partial<{ state: "idle" | "running" | "degraded" | "error"; providerHealth: "unknown" | "ok" | "degraded"; fallbackMode: string | null; detail: string }>): void {
-    this.aiStatus = {
-      ...this.aiStatus,
-      ...patch,
-      updatedAt: new Date().toISOString()
-    };
-    this.emitMeta({ ai: this.getAiStatus() });
-  }
-
-  public getAiStatus(): { state: string; providerHealth: string; fallbackMode: string | null; detail: string; updatedAt: string } {
-    return { ...this.aiStatus };
-  }
-
-  private setAiStatus(patch: Partial<{ state: "idle" | "running" | "degraded" | "error"; providerHealth: "unknown" | "ok" | "degraded"; fallbackMode: string | null; detail: string }>): void {
+  private setAiStatus(
+    patch: Partial<{ state: "idle" | "running" | "degraded" | "error"; providerHealth: "unknown" | "ok" | "degraded"; fallbackMode: string | null; detail: string }>
+  ): void {
     this.aiStatus = {
       ...this.aiStatus,
       ...patch,
@@ -114,6 +103,10 @@ export class SimulationOrchestrator {
       return { phase: "retrying", message: `Cloud request retry ${attempt}/${maxRetries} after: ${reason}`, blocking: false };
     }
     return { phase: "degraded", message: `Cloud retries exhausted. Entering degraded recovery state: ${reason}`, blocking: false };
+  }
+
+  private tagMessages(messages: ChatMessage[], source: ChatMessage["source"]): ChatMessage[] {
+    return messages.map((message) => ({ ...message, source: message.source ?? source ?? "unknown" }));
   }
 
   private async loop(): Promise<void> {
@@ -169,7 +162,7 @@ export class SimulationOrchestrator {
           this.emitMeta({ warnings: [recovery.message], cloudRecovery: recovery.phase, blocked: recovery.blocking });
         });
         try {
-          messages = parseInferenceOutput(rawOutput);
+          messages = this.tagMessages(parseInferenceOutput(rawOutput), "real-inference");
         } catch (parseError) {
           const malformedClass = classifyMalformedOutput(rawOutput);
           const action = recommendedRecoveryAction(malformedClass);
@@ -177,7 +170,7 @@ export class SimulationOrchestrator {
 
           if ((action === "repair" || action === "regenerate") && config.safety.regenerateOnMalformedJson) {
             const retryOutput = await provider.generate(payload, config);
-            messages = parseInferenceOutput(retryOutput);
+            messages = this.tagMessages(parseInferenceOutput(retryOutput), "real-inference");
             this.emitMeta({ warnings: [`Malformed inference JSON recovered via ${action} fallback.`], blocked: false, malformedClass, action });
             this.obs.log("malformed_json_counter", { malformedClass, action, stage: "recovered" });
           } else {
@@ -193,9 +186,18 @@ export class SimulationOrchestrator {
 
         try {
           const fallbackOutput = await this.mockProvider.generate(payload, { ...config, inferenceMode: "mock-local" });
-          messages = parseInferenceOutput(fallbackOutput);
+          messages = this.tagMessages(parseInferenceOutput(fallbackOutput), "fallback-mock");
           this.setAiStatus({ state: "degraded", providerHealth: "degraded", fallbackMode: "mock-local", detail: `Primary inference failed; mock fallback active: ${reason}` });
-          this.emitMeta({ warnings: [reason, "Fallback engaged: mock-local"], dropped: false, blocked: false, cloudRecovery: "degraded" });
+          this.emitMeta({
+            warnings: [reason, "Fallback engaged: mock-local"],
+            dropped: false,
+            blocked: false,
+            cloudRecovery: "degraded",
+            source: "fallback-mock",
+            provider: config.inferenceMode,
+            timeoutMs: config.provider.requestTimeoutMs,
+            retries: config.provider.maxRetries
+          });
         } catch (fallbackError) {
           const fallbackReason = (fallbackError as Error).message;
           this.setAiStatus({ state: "error", providerHealth: "degraded", fallbackMode: null, detail: `Fallback failed: ${fallbackReason}` });
@@ -246,6 +248,7 @@ export class SimulationOrchestrator {
         timing,
         audioState: this.getAudioState(),
         inferenceMode: config.inferenceMode,
+        providerSource: safeMessages[0]?.source ?? "unknown",
         requestedMessageCount: payload.requestedMessageCount,
         latencyMs,
         captureLatencyMs,
@@ -260,7 +263,12 @@ export class SimulationOrchestrator {
           targetMs: 3000,
           withinTarget: latencyMs <= 3000
         },
-        ai: this.getAiStatus()
+        ai: this.getAiStatus(),
+        providerDiagnostics: {
+          timeoutMs: config.provider.requestTimeoutMs,
+          retries: config.provider.maxRetries,
+          fallbackActive: this.aiStatus.fallbackMode !== null
+        }
       });
     }
 

--- a/tests/hardeningFlows.test.ts
+++ b/tests/hardeningFlows.test.ts
@@ -84,6 +84,11 @@ describe("malformed json fallback + stt pause", () => {
     expect(parsed).toHaveLength(1);
   });
 
+  it("preserves source tags from inference payload", () => {
+    const parsed = parseInferenceOutput('{"messages":[{"username":"u","text":"hi","emotes":[],"source":"fallback-mock"}]}');
+    expect(parsed[0]?.source).toBe("fallback-mock");
+  });
+
   it("pauses mic ingest when stt is paused", () => {
     sharedDeviceCapturePipeline.reset();
     sharedSttEngine.pause();

--- a/tests/uiRuntimeVerification.test.ts
+++ b/tests/uiRuntimeVerification.test.ts
@@ -20,6 +20,9 @@ describe("runtime verification + monitoring UI wiring", () => {
     expect(appJs).toContain("liveMonitorEnabled?.addEventListener(\"change\"");
     expect(appJs).toContain('const liveVideo = document.getElementById("liveVideo")');
     expect(appJs).toContain('const voiceMeter = document.getElementById("voiceMeter")');
+    expect(appJs).toContain("getUserMedia({ audio: true, video: true })");
+    expect(appJs).toContain("function updateMonitorAvailability(verification)");
+    expect(appJs).toContain("source.className = \"source-tag\"");
   });
 
   it("keeps runtime verification and live monitor markup IDs in index.html", () => {
@@ -45,6 +48,7 @@ describe("runtime verification + monitoring UI wiring", () => {
     expect(stylesCss).toContain(".live-monitor-grid");
     expect(stylesCss).toContain("#liveVideo");
     expect(stylesCss).toContain("#voiceMeter");
+    expect(stylesCss).toContain(".source-tag");
   });
 
   it("keeps runtime defaults aligned for onboarding + hardware verification", () => {


### PR DESCRIPTION
### Motivation
- Fix runtime verification blockers so the Live Monitor only enables after both microphone and camera permissions plus device presence are confirmed. 
- Restore/verify that the audio analyser path drives the visual voice meter and expose why the system may fall back to mocks so operators can diagnose degraded AI health.
- Make it obvious in the UI/logs whether messages originate from real inference or mock fallbacks to help triage overly-eager mock fallbacks.

### Description
- Added `updateMonitorAvailability(verification)` and wired it into the Verify Mic/Camera flow and boot sequence so the Live Monitor toggle is disabled until `micPermission && cameraPermission && hasMicDevice && hasCameraDevice` are true, and it stops the monitor + updates status text when unavailable (changes in `src/public/app.js`).
- Kept and exercised the `AnalyserNode` path and voice-meter draw path, and ensured the monitor is explicitly disabled at boot until verification is run (changes in `src/public/app.js`).
- Added per-message `source` badges in the chat UI and styles for `.source-tag` so messages show `real-inference` / `mock-audience` / `fallback-mock` etc. (changes in `src/public/app.js` and `src/public/styles.css`).
- Added structured `MessageSource` and optional `source` on `ChatMessage`, preserved known `source` values in the parser, and tagged mock audience messages as `mock-audience` (changes in `src/core/types.ts`, `src/pipeline/outputParser.ts`, `src/llm/mockAudienceGenerator.ts`).
- Enhanced `SimulationOrchestrator` to tag parsed messages as `real-inference` or `fallback-mock`, and emit richer fallback/provider diagnostics (`providerSource`, `providerDiagnostics`, `timeoutMs`, `retries`) in the meta stream when degraded fallback occurs (changes in `src/services/simulationOrchestrator.ts`).
- Updated tests to assert the runtime verification wiring, presence of the combined `getUserMedia({ audio: true, video: true })` check, UI `source` badge wiring, and that parser preserves `source` tags (changes in `tests/uiRuntimeVerification.test.ts` and `tests/hardeningFlows.test.ts`).

### Testing
- Built the project with `npm run build` and the TypeScript build completed successfully. 
- Ran the full test suite with `npm test` and all tests passed. 
- Ran focused tests `npm test -- tests/uiRuntimeVerification.test.ts tests/hardeningFlows.test.ts` which also passed, validating the new UI wiring and parser/source preservation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b59ed4494483249a05f68f37069478)