### PR TITLE
Disable camera verification and keep live monitor inactive

### DIFF
--- a/src/public/app.js
+++ b/src/public/app.js
@@ -617,16 +617,8 @@ verifyMicBtn?.addEventListener("click", async () => {
 });
 
 verifyCameraBtn?.addEventListener("click", async () => {
-  const verification = await runAction({
-    button: verifyCameraBtn,
-    pendingText: "Requesting camera permission...",
-    successText: "Camera verification complete.",
-    onRun: () => verifyCameraOnly()
-  });
-  if (!verification) return;
-  latestDeviceVerification = verification;
-  renderDeviceChecks(verification);
-  updateMonitorAvailability(verification);
+  setStatus("Camera verification is intentionally disabled in this build.", "warn");
+  setLiveMonitorStatus("Camera verification is disabled, so live monitoring remains inactive.", "warn");
 });
 
 openOverlayWindowBtn.addEventListener("click", () => {
@@ -766,7 +758,10 @@ async function boot() {
     liveMonitorEnabled.checked = false;
     liveMonitorEnabled.disabled = true;
   }
-  setLiveMonitorStatus("Run Verify Mic/Camera to enable the live monitor.", "warn");
+  setLiveMonitorStatus("Camera verification is disabled; live monitor stays inactive.", "warn");
+  if (verifyCameraBtn) {
+    verifyCameraBtn.disabled = true;
+  }
 }
 
 void boot();

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -135,7 +135,7 @@
           <button id="stop" type="button">Stop</button>
           <button id="refreshStatus" type="button">Refresh Status</button>
           <button id="verifyMic" type="button">Verify Microphone</button>
-          <button id="verifyCamera" type="button">Verify Camera</button>
+          <button id="verifyCamera" type="button" disabled>Verify Camera (inactive)</button>
           <button id="openOverlayWindow" type="button">Open Transparent Chat Window</button>
         </div>
         <p id="statusBanner" class="status-banner" aria-live="polite">Ready.</p>

--- a/tests/uiRuntimeVerification.test.ts
+++ b/tests/uiRuntimeVerification.test.ts
@@ -24,7 +24,6 @@ describe("runtime verification + monitoring UI wiring", () => {
     expect(appJs).toContain('const liveVideo = document.getElementById("liveVideo")');
     expect(appJs).toContain('const voiceMeter = document.getElementById("voiceMeter")');
     expect(appJs).toContain("getUserMedia({ audio: true })");
-    expect(appJs).toContain("getUserMedia({ video: true })");
     expect(appJs).toContain("function updateMonitorAvailability(verification)");
     expect(appJs).toContain("source.className = \"source-tag\"");
   });
@@ -36,6 +35,7 @@ describe("runtime verification + monitoring UI wiring", () => {
     expect(indexHtml).toContain('id="runtimeSummary"');
     expect(indexHtml).toContain('id="verifyMic"');
     expect(indexHtml).toContain('id="verifyCamera"');
+    expect(indexHtml).toContain("Verify Camera (inactive)");
     expect(indexHtml).toContain('id="liveMonitorEnabled"');
     expect(indexHtml).toContain('id="liveMonitorStatus"');
     expect(indexHtml).toContain('id="liveVideo"');


### PR DESCRIPTION
### Motivation

- Prevent the app from triggering a camera permission prompt and ensure live monitoring remains inactive in builds where camera verification should not run.

### Description

- Disabled the `Verify Camera` UI control and relabeled it as inactive in `src/public/index.html` so users cannot trigger camera permission requests from the button. 
- Replaced the camera verification click handler in `src/public/app.js` so it no longer calls `getUserMedia` and instead displays a warning that camera verification is disabled. 
- Ensured live monitor remains disabled at boot with an explicit status message and programmatically disabled the camera verify button at initialization in `src/public/app.js`. 
- Updated `tests/uiRuntimeVerification.test.ts` expectations to reflect the inactive camera button and adjusted checks to not require video `getUserMedia` text.

### Testing

- Ran the UI unit test with `npm test -- tests/uiRuntimeVerification.test.ts` and all tests passed (4 tests). 
- Captured a headless browser screenshot of the updated UI via Playwright to validate the inactive camera button and live monitor state (artifact produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5a737dc208324b689da0a7c0f6f79)