### PR TITLE
Add post-mic STT verification voice meter and caption probe

### DIFF
--- a/src/capture/sttEngine.ts
+++ b/src/capture/sttEngine.ts
@@ -54,6 +54,7 @@ export interface SttEngine {
   pause(): void;
   resume(): void;
   state(): { paused: boolean; provider: SttProviderKind };
+  transcribeFrame(frame: Buffer): Promise<string>;
   ingestAudioFrame(frame: Buffer): Promise<void>;
   bindAudioStream(stream: Readable): void;
 }
@@ -87,9 +88,14 @@ export class DeviceSttEngine implements SttEngine {
     return { paused: this.paused, provider: this.provider };
   }
 
+  public async transcribeFrame(frame: Buffer): Promise<string> {
+    if (frame.length === 0) return "";
+    return this.backend.transcribe(frame);
+  }
+
   public async ingestAudioFrame(frame: Buffer): Promise<void> {
     if (this.paused || frame.length === 0) return;
-    const transcriptChunk = await this.backend.transcribe(frame);
+    const transcriptChunk = await this.transcribeFrame(frame);
     if (!transcriptChunk) return;
 
     const paceWpm = Math.max(70, Math.min(220, Math.round((transcriptChunk.split(/\s+/).length / 2) * 60)));

--- a/src/public/app.js
+++ b/src/public/app.js
@@ -12,10 +12,19 @@ const liveMonitorEnabled = document.getElementById("liveMonitorEnabled");
 const liveMonitorStatus = document.getElementById("liveMonitorStatus");
 const liveVideo = document.getElementById("liveVideo");
 const voiceMeter = document.getElementById("voiceMeter");
+const sttCaptionStatus = document.getElementById("sttCaptionStatus");
+const sttCaptionPreview = document.getElementById("sttCaptionPreview");
 
 let liveMonitorStream = null;
 let liveMonitorAudioContext = null;
 let liveMonitorMeterInterval = null;
+let micCheckStream = null;
+let micCheckAudioContext = null;
+let micCheckMeterInterval = null;
+let micCheckDataInterval = null;
+let micCheckQueuedPcm = [];
+let micCheckProbeInFlight = false;
+let latestCaptionText = "";
 let latestStatusPayload = null;
 let latestDeviceVerification = {
   micPermission: false,
@@ -70,6 +79,93 @@ function setLiveMonitorStatus(message, tone = "warn") {
   liveMonitorStatus.classList.add(tone);
 }
 
+function setCaptionStatus(message, tone = "warn") {
+  if (!sttCaptionStatus) return;
+  sttCaptionStatus.textContent = message;
+  sttCaptionStatus.classList.remove("ok", "warn", "error");
+  sttCaptionStatus.classList.add(tone);
+}
+
+function setCaptionPreview(text) {
+  if (!sttCaptionPreview) return;
+  sttCaptionPreview.textContent = text?.trim() || "No speech captured yet.";
+}
+
+function encodePcm16Wav(samples, sampleRate) {
+  const dataLength = samples.length * 2;
+  const buffer = new ArrayBuffer(44 + dataLength);
+  const view = new DataView(buffer);
+  const writeString = (offset, value) => {
+    for (let i = 0; i < value.length; i += 1) view.setUint8(offset + i, value.charCodeAt(i));
+  };
+
+  writeString(0, "RIFF");
+  view.setUint32(4, 36 + dataLength, true);
+  writeString(8, "WAVE");
+  writeString(12, "fmt ");
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);
+  view.setUint16(22, 1, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, sampleRate * 2, true);
+  view.setUint16(32, 2, true);
+  view.setUint16(34, 16, true);
+  writeString(36, "data");
+  view.setUint32(40, dataLength, true);
+
+  let offset = 44;
+  for (let i = 0; i < samples.length; i += 1) {
+    const sample = Math.max(-1, Math.min(1, samples[i]));
+    view.setInt16(offset, sample < 0 ? sample * 0x8000 : sample * 0x7fff, true);
+    offset += 2;
+  }
+
+  return buffer;
+}
+
+function arrayBufferToBase64(buffer) {
+  const bytes = new Uint8Array(buffer);
+  let binary = "";
+  const chunkSize = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize));
+  }
+  return btoa(binary);
+}
+
+async function probeSttFromMicChunk() {
+  if (micCheckProbeInFlight || micCheckQueuedPcm.length < 2000) return;
+
+  const sampleRate = micCheckAudioContext?.sampleRate ?? 44100;
+  const clipSize = Math.min(micCheckQueuedPcm.length, Math.floor(sampleRate * 1.5));
+  const clip = micCheckQueuedPcm.slice(-clipSize);
+  micCheckQueuedPcm = micCheckQueuedPcm.slice(-Math.floor(sampleRate * 2.5));
+
+  const wav = encodePcm16Wav(clip, sampleRate);
+  const audioBase64 = arrayBufferToBase64(wav);
+
+  micCheckProbeInFlight = true;
+  try {
+    const result = await post("/api/stt/probe", {
+      audioBase64,
+      provider: controls.sttProvider.value,
+      endpoint: controls.sttEndpoint.value
+    });
+
+    const transcript = (result?.transcript ?? "").trim();
+    if (transcript) {
+      latestCaptionText = transcript;
+      setCaptionPreview(transcript);
+    }
+    setCaptionStatus(`Mic stream active · STT(${result.provider}) ${transcript ? "captured transcript" : "reachable; waiting for speech"}.`, "ok");
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    setCaptionStatus(`Mic stream active but STT probe failed: ${message}`, "error");
+  } finally {
+    micCheckProbeInFlight = false;
+  }
+}
+
 function drawVoiceMeter(level) {
   if (!voiceMeter) return;
   const ctx = voiceMeter.getContext("2d");
@@ -88,6 +184,80 @@ function drawVoiceMeter(level) {
   ctx.fillRect(0, 0, meterWidth, height);
   ctx.strokeStyle = "#334155";
   ctx.strokeRect(0, 0, width, height);
+}
+
+function stopMicVerificationCheck() {
+  if (micCheckMeterInterval) {
+    clearInterval(micCheckMeterInterval);
+    micCheckMeterInterval = null;
+  }
+  if (micCheckDataInterval) {
+    clearInterval(micCheckDataInterval);
+    micCheckDataInterval = null;
+  }
+  if (micCheckAudioContext) {
+    void micCheckAudioContext.close();
+    micCheckAudioContext = null;
+  }
+  if (micCheckStream) {
+    micCheckStream.getTracks().forEach((track) => track.stop());
+    micCheckStream = null;
+  }
+  micCheckQueuedPcm = [];
+  micCheckProbeInFlight = false;
+}
+
+async function startMicVerificationCheck() {
+  stopMicVerificationCheck();
+  if (!navigator.mediaDevices?.getUserMedia) {
+    setCaptionStatus("Browser does not support microphone verification stream.", "error");
+    return;
+  }
+
+  const stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: false });
+  micCheckStream = stream;
+  const AudioContextCtor = window.AudioContext || window.webkitAudioContext;
+  if (!AudioContextCtor) {
+    setCaptionStatus("Microphone granted, but AudioContext is unavailable in this browser.", "warn");
+    return;
+  }
+
+  micCheckAudioContext = new AudioContextCtor();
+  const source = micCheckAudioContext.createMediaStreamSource(stream);
+  const analyser = micCheckAudioContext.createAnalyser();
+  analyser.fftSize = 256;
+  source.connect(analyser);
+
+  const processor = micCheckAudioContext.createScriptProcessor(4096, 1, 1);
+  source.connect(processor);
+  processor.connect(micCheckAudioContext.destination);
+  processor.onaudioprocess = (event) => {
+    const input = event.inputBuffer.getChannelData(0);
+    micCheckQueuedPcm.push(...input);
+    const maxSamples = Math.floor((micCheckAudioContext?.sampleRate ?? 44100) * 4);
+    if (micCheckQueuedPcm.length > maxSamples) {
+      micCheckQueuedPcm = micCheckQueuedPcm.slice(-maxSamples);
+    }
+  };
+
+  const samples = new Uint8Array(analyser.frequencyBinCount);
+  micCheckMeterInterval = setInterval(() => {
+    analyser.getByteTimeDomainData(samples);
+    let sum = 0;
+    for (let i = 0; i < samples.length; i += 1) {
+      const centered = (samples[i] - 128) / 128;
+      sum += centered * centered;
+    }
+    const rms = Math.sqrt(sum / samples.length);
+    drawVoiceMeter(Math.min(1, rms * 3.2));
+  }, 80);
+
+  micCheckDataInterval = setInterval(() => {
+    void probeSttFromMicChunk();
+  }, 1800);
+
+  setCaptionStatus("Mic stream active. Speak a short phrase to verify STT transcript.", "ok");
+  setCaptionPreview(latestCaptionText || "Listening for speech...");
 }
 
 function stopLiveMonitor() {
@@ -655,6 +825,15 @@ verifyMicBtn?.addEventListener("click", async () => {
   latestDeviceVerification = verification;
   renderDeviceChecks(verification);
   updateMonitorAvailability(verification);
+
+  if (verification.micPermission && verification.hasMicDevice) {
+    try {
+      await startMicVerificationCheck();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      setCaptionStatus(`Unable to start mic/STT check: ${message}`, "error");
+    }
+  }
 });
 
 ensureVerifyCameraButtonActive();
@@ -761,6 +940,7 @@ liveMonitorEnabled?.addEventListener("change", async () => {
 
 window.addEventListener("beforeunload", () => {
   stopLiveMonitor();
+  stopMicVerificationCheck();
 });
 
 const events = new EventSource("/api/events");
@@ -826,6 +1006,9 @@ async function boot() {
     liveMonitorEnabled.disabled = true;
   }
   setLiveMonitorStatus("Run Verify Mic/Camera to enable the live monitor.", "warn");
+  stopMicVerificationCheck();
+  setCaptionPreview("No speech captured yet.");
+  setCaptionStatus("Run Verify Microphone to start mic/STT check.", "warn");
   ensureVerifyCameraButtonActive();
 }
 

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -135,7 +135,7 @@
           <button id="stop" type="button">Stop</button>
           <button id="refreshStatus" type="button">Refresh Status</button>
           <button id="verifyMic" type="button">Verify Microphone</button>
-          <button id="verifyCamera" type="button" disabled>Verify Camera (inactive)</button>
+          <button id="verifyCamera" type="button" disabled>Verify Camera</button>
           <button id="openOverlayWindow" type="button">Open Transparent Chat Window</button>
         </div>
         <p id="statusBanner" class="status-banner" aria-live="polite">Ready.</p>
@@ -147,6 +147,8 @@
           <pre id="sttHealthSummary">STT health pending...</pre>
           <label class="live-monitor-toggle"><input id="liveMonitorEnabled" type="checkbox" /> Enable live camera + voice monitor</label>
           <p id="liveMonitorStatus" class="monitor-status">Live monitor disabled.</p>
+          <p id="sttCaptionStatus" class="monitor-status">Run Verify Microphone to start mic/STT check.</p>
+          <div id="sttCaptionPreview" class="caption-preview" aria-live="polite">No speech captured yet.</div>
           <div class="live-monitor-grid">
             <video id="liveVideo" autoplay playsinline muted></video>
             <canvas id="voiceMeter" width="280" height="80" aria-label="Voice meter"></canvas>

--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -218,3 +218,15 @@ pre { margin-top: 12px; background: #0c0e14; border: 1px solid #293145; border-r
   min-height: 82px;
   margin-top: 8px;
 }
+
+.caption-preview {
+  min-height: 56px;
+  margin-bottom: 8px;
+  border: 1px solid #334155;
+  border-radius: 8px;
+  background: #020617;
+  padding: 8px 10px;
+  font-size: 0.84rem;
+  color: #cbd5e1;
+  line-height: 1.35;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -209,6 +209,27 @@ app.post("/api/capture/mic-frame", (req, res) => {
   res.json({ ok: true });
 });
 
+app.post("/api/stt/probe", async (req, res) => {
+  const base64 = typeof req.body?.audioBase64 === "string" ? req.body.audioBase64 : "";
+  if (!base64) {
+    res.status(400).json({ ok: false, error: "audioBase64 is required." });
+    return;
+  }
+
+  const provider = (typeof req.body?.provider === "string" ? req.body.provider : config.capture.sttProvider) as typeof config.capture.sttProvider;
+  const endpoint = typeof req.body?.endpoint === "string" ? req.body.endpoint : config.capture.sttEndpoint;
+  const frame = Buffer.from(base64, "base64");
+
+  try {
+    sharedSttEngine.configure(provider, endpoint);
+    const transcript = await sharedSttEngine.transcribeFrame(frame);
+    res.json({ ok: true, provider, endpoint, transcript });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    res.status(502).json({ ok: false, provider, endpoint, error: message });
+  }
+});
+
 app.post("/api/capture/audio-chunk", async (req, res) => {
   const base64 = typeof req.body?.audioBase64 === "string" ? req.body.audioBase64 : "";
   if (!base64) {


### PR DESCRIPTION
### Motivation
- Provide an immediate, post-microphone-check visual + textual verification so operators can confirm the mic stream is active and that local/cloud STT providers can receive and transcribe audio.

### Description
- Added short caption preview and status UI elements and styles to surface live STT reachability and a short transcribed snippet (`src/public/index.html`, `src/public/styles.css`).
- Implemented a mic-only verification flow that starts after `Verify Microphone` and drives the existing voice meter while buffering short PCM clips for STT probing (`startMicVerificationCheck`, `stopMicVerificationCheck`, `probeSttFromMicChunk` in `src/public/app.js`).
- Added a new backend probe route `/api/stt/probe` that accepts base64 WAV audio and returns a quick transcription for reachability/debugging (`src/server.ts`).
- Exposed `transcribeFrame()` on the STT engine and used it from the probe route so probes do not inject into the main ingestion pipeline (`src/capture/sttEngine.ts`).

### Testing
- Ran `npm run build` successfully to compile TypeScript assets and confirm no type errors.
- Ran `npm test` and all test suites passed (`53` tests passed across `14` files).
- Attempted to capture a UI screenshot via Playwright to validate the new UI, but the Chromium launch crashed in this environment (SIGSEGV), so no screenshot artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b71a2a16bc8324a522b0e0457b09d8)