### PR TITLE
Add OpenAI Whisper cloud STT and improve STT probe resiliency

### DIFF
--- a/src/capture/sttEngine.ts
+++ b/src/capture/sttEngine.ts
@@ -1,11 +1,16 @@
 import { Readable } from "node:stream";
+import { SecretStore } from "../security/secretStore.js";
 import { sharedDeviceCapturePipeline } from "./deviceCapturePipeline.js";
 
-export type SttProviderKind = "mock" | "local-whisper" | "whispercpp" | "deepgram";
+export type SttProviderKind = "mock" | "local-whisper" | "whispercpp" | "deepgram" | "openai-whisper";
 
 interface SttBackend {
   transcribe(frame: Buffer): Promise<string>;
 }
+
+const DEFAULT_LOCAL_STT_ENDPOINT = "http://127.0.0.1:7778/stt";
+const DEFAULT_DEEPGRAM_ENDPOINT = "https://api.deepgram.com/v1/listen?model=nova-2&punctuate=true";
+const DEFAULT_OPENAI_STT_ENDPOINT = "https://api.openai.com/v1/audio/transcriptions";
 
 class MockSttBackend implements SttBackend {
   public async transcribe(frame: Buffer): Promise<string> {
@@ -18,12 +23,17 @@ class WhisperCppBackend implements SttBackend {
   constructor(private readonly endpoint: string) {}
 
   public async transcribe(frame: Buffer): Promise<string> {
-    const response = await fetch(this.endpoint, {
-      method: "POST",
-      headers: { "Content-Type": "application/octet-stream" },
-      body: new Uint8Array(frame),
-      signal: AbortSignal.timeout(2500)
-    });
+    let response: Response;
+    try {
+      response = await fetch(this.endpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/octet-stream" },
+        body: new Uint8Array(frame),
+        signal: AbortSignal.timeout(2500)
+      });
+    } catch (error) {
+      throw new Error(`Whisper STT request failed for ${this.endpoint}: ${(error as Error).message}`);
+    }
     if (!response.ok) throw new Error(`Whisper STT failed (${response.status}).`);
     const json = (await response.json()) as { text?: string };
     return json.text?.trim() ?? "";
@@ -35,18 +45,58 @@ class DeepgramBackend implements SttBackend {
 
   public async transcribe(frame: Buffer): Promise<string> {
     if (!this.apiKey) throw new Error("Deepgram API key missing.");
-    const response = await fetch(this.endpoint, {
-      method: "POST",
-      headers: {
-        Authorization: `Token ${this.apiKey}`,
-        "Content-Type": "audio/wav"
-      },
-      body: new Uint8Array(frame),
-      signal: AbortSignal.timeout(2500)
-    });
+    let response: Response;
+    try {
+      response = await fetch(this.endpoint, {
+        method: "POST",
+        headers: {
+          Authorization: `Token ${this.apiKey}`,
+          "Content-Type": "audio/wav"
+        },
+        body: new Uint8Array(frame),
+        signal: AbortSignal.timeout(2500)
+      });
+    } catch (error) {
+      throw new Error(`Deepgram STT request failed for ${this.endpoint}: ${(error as Error).message}`);
+    }
     if (!response.ok) throw new Error(`Deepgram STT failed (${response.status}).`);
     const json = (await response.json()) as { transcript?: string; results?: { channels?: Array<{ alternatives?: Array<{ transcript?: string }> }> } };
     return json.transcript?.trim() ?? json.results?.channels?.[0]?.alternatives?.[0]?.transcript?.trim() ?? "";
+  }
+}
+
+class OpenAiWhisperBackend implements SttBackend {
+  private readonly secretStore = new SecretStore();
+
+  constructor(private readonly endpoint: string, private readonly model: string) {}
+
+  public async transcribe(frame: Buffer): Promise<string> {
+    const apiKey = this.secretStore.getCloudApiKey();
+    if (!apiKey) throw new Error("Cloud API key missing. Save Cloud API key in Secrets + Maintenance.");
+
+    const form = new FormData();
+    const audioBlob = new Blob([new Uint8Array(frame)], { type: "audio/wav" });
+    form.append("file", audioBlob, "mic-probe.wav");
+    form.append("model", this.model);
+    form.append("response_format", "json");
+
+    let response: Response;
+    try {
+      response = await fetch(this.endpoint, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${apiKey}` },
+        body: form,
+        signal: AbortSignal.timeout(10000)
+      });
+    } catch (error) {
+      throw new Error(`OpenAI Whisper request failed for ${this.endpoint}: ${(error as Error).message}`);
+    }
+
+    if (!response.ok) {
+      throw new Error(`OpenAI Whisper STT failed (${response.status}).`);
+    }
+    const json = (await response.json()) as { text?: string };
+    return json.text?.trim() ?? "";
   }
 }
 
@@ -120,17 +170,32 @@ export class DeviceSttEngine implements SttEngine {
   private createBackend(provider: SttProviderKind, endpoint?: string): SttBackend {
     switch (provider) {
       case "local-whisper":
-        return new WhisperCppBackend(endpoint ?? process.env.STREAMSIM_LOCAL_STT_ENDPOINT ?? "http://127.0.0.1:7778/stt");
+        return new WhisperCppBackend(endpoint ?? process.env.STREAMSIM_LOCAL_STT_ENDPOINT ?? DEFAULT_LOCAL_STT_ENDPOINT);
       case "whispercpp":
-        return new WhisperCppBackend(endpoint ?? process.env.STREAMSIM_WHISPER_ENDPOINT ?? "http://127.0.0.1:7778/stt");
+        return new WhisperCppBackend(endpoint ?? process.env.STREAMSIM_WHISPER_ENDPOINT ?? DEFAULT_LOCAL_STT_ENDPOINT);
       case "deepgram":
         return new DeepgramBackend(
-          process.env.STREAMSIM_DEEPGRAM_ENDPOINT ?? "https://api.deepgram.com/v1/listen?model=nova-2&punctuate=true",
+          this.resolveProviderEndpoint(provider, endpoint, process.env.STREAMSIM_DEEPGRAM_ENDPOINT ?? DEFAULT_DEEPGRAM_ENDPOINT),
           process.env.STREAMSIM_DEEPGRAM_API_KEY
+        );
+      case "openai-whisper":
+        return new OpenAiWhisperBackend(
+          this.resolveProviderEndpoint(provider, endpoint, process.env.STREAMSIM_OPENAI_STT_ENDPOINT ?? DEFAULT_OPENAI_STT_ENDPOINT),
+          process.env.STREAMSIM_OPENAI_STT_MODEL ?? "gpt-4o-mini-transcribe"
         );
       default:
         return new MockSttBackend();
     }
+  }
+
+  private resolveProviderEndpoint(provider: "deepgram" | "openai-whisper", requestedEndpoint: string | undefined, fallback: string): string {
+    if (!requestedEndpoint) return fallback;
+    const normalized = requestedEndpoint.trim();
+    if (!normalized) return fallback;
+    if (provider === "openai-whisper" && normalized === DEFAULT_LOCAL_STT_ENDPOINT) {
+      return fallback;
+    }
+    return normalized;
   }
 }
 

--- a/src/config/configMigrations.ts
+++ b/src/config/configMigrations.ts
@@ -17,7 +17,11 @@ function migrateV1toV2(input: Record<string, unknown>): Record<string, unknown> 
     capture: {
       ...capture,
       sttProvider:
-        capture.sttProvider === "mock" || capture.sttProvider === "local-whisper" || capture.sttProvider === "whispercpp" || capture.sttProvider === "deepgram"
+        capture.sttProvider === "mock" ||
+        capture.sttProvider === "local-whisper" ||
+        capture.sttProvider === "whispercpp" ||
+        capture.sttProvider === "deepgram" ||
+        capture.sttProvider === "openai-whisper"
           ? capture.sttProvider
           : defaultConfig.capture.sttProvider
     }

--- a/src/config/runtimeConfig.ts
+++ b/src/config/runtimeConfig.ts
@@ -96,6 +96,7 @@ export function sanitizeConfig(input: unknown): SimulationConfig {
         capture.sttProvider === "local-whisper" ||
         capture.sttProvider === "whispercpp" ||
         capture.sttProvider === "deepgram" ||
+        capture.sttProvider === "openai-whisper" ||
         capture.sttProvider === "mock"
           ? capture.sttProvider
           : defaultConfig.capture.sttProvider,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -8,7 +8,7 @@ export interface CaptureConfig {
   visionIntervalSec: number;
   useRealCapture: boolean;
   sttEndpoint: string;
-  sttProvider: "mock" | "local-whisper" | "whispercpp" | "deepgram";
+  sttProvider: "mock" | "local-whisper" | "whispercpp" | "deepgram" | "openai-whisper";
   visionEndpoint: string;
 }
 

--- a/src/public/app.js
+++ b/src/public/app.js
@@ -39,6 +39,13 @@ const MIC_CHECK_PROBE_SECONDS = 0.6;
 const MIC_CHECK_BUFFER_SECONDS = 1.8;
 const MIC_CHECK_MIN_SAMPLES = 2000;
 const CAMERA_FRAME_CONFIRM_TIMEOUT_MS = 3000;
+const STT_DEFAULT_ENDPOINTS = {
+  "local-whisper": "http://127.0.0.1:7778/stt",
+  whispercpp: "http://127.0.0.1:7778/stt",
+  deepgram: "https://api.deepgram.com/v1/listen?model=nova-2&punctuate=true",
+  "openai-whisper": "https://api.openai.com/v1/audio/transcriptions",
+  mock: "http://127.0.0.1:7778/stt"
+};
 
 const controls = {
   viewerCount: document.getElementById("viewerCount"),
@@ -447,12 +454,21 @@ function hydrateControls(config) {
   controls.useRealCapture.checked = config.capture.useRealCapture;
   controls.visionIntervalSec.value = config.capture.visionIntervalSec;
   controls.sttProvider.value = config.capture.sttProvider ?? "local-whisper";
-  controls.sttEndpoint.value = config.capture.sttEndpoint;
+  controls.sttEndpoint.value = config.capture.sttEndpoint || STT_DEFAULT_ENDPOINTS[controls.sttProvider.value] || STT_DEFAULT_ENDPOINTS["local-whisper"];
   controls.visionEndpoint.value = config.capture.visionEndpoint;
   controls.allowDiagnostics.checked = config.security.allowDiagnostics;
   controls.allowNonLocalSidecarOverride.checked = config.security.allowNonLocalSidecarOverride;
   controls.eulaAccepted.checked = config.compliance.eulaAccepted;
   if (wizardEulaAccepted) wizardEulaAccepted.checked = config.compliance.eulaAccepted;
+}
+
+function syncSttEndpointForProvider() {
+  const provider = controls.sttProvider.value;
+  const currentEndpoint = controls.sttEndpoint.value?.trim();
+  const knownDefaults = new Set(Object.values(STT_DEFAULT_ENDPOINTS));
+  if (!currentEndpoint || knownDefaults.has(currentEndpoint)) {
+    controls.sttEndpoint.value = STT_DEFAULT_ENDPOINTS[provider] || STT_DEFAULT_ENDPOINTS["local-whisper"];
+  }
 }
 
 
@@ -567,6 +583,9 @@ function summarizeSttHealth(payload) {
   } else if (provider === "deepgram" && !sttRuntime.deepgramKeyPresent) {
     ready = false;
     detail = "Deepgram selected but STREAMSIM_DEEPGRAM_API_KEY is missing";
+  } else if (provider === "openai-whisper" && !sttRuntime.cloudKeyPresent) {
+    ready = false;
+    detail = "OpenAI Whisper selected but no cloud API key is stored";
   } else if ((provider === "whispercpp" || provider === "local-whisper") && !endpoint.startsWith("http")) {
     ready = false;
     detail = "Whisper endpoint must be a valid URL";
@@ -781,12 +800,16 @@ startBtn.addEventListener("click", async () => {
     onRun: async () => {
       const mode = controls.inferenceMode.value;
       const cloudMode = mode === "openai" || mode === "groq" || mode === "mock-cloud";
+      const cloudStt = controls.useRealCapture.checked && controls.sttProvider.value === "openai-whisper";
       const hasCloudKey = Boolean(latestStatusPayload?.secrets?.hasCloudKey);
       if (cloudMode && !hasCloudKey) {
         throw new Error("Cloud inference selected but no API key is stored. Save a Cloud API key before starting.");
       }
       if (controls.ttsEnabled.checked && controls.ttsMode.value === "cloud" && !hasCloudKey) {
         throw new Error("Cloud TTS selected but no API key is stored. Save a Cloud API key or switch TTS path to local.");
+      }
+      if (cloudStt && !hasCloudKey) {
+        throw new Error("OpenAI Whisper STT selected but no API key is stored. Save a Cloud API key or switch STT provider.");
       }
       return post("/api/start");
     }
@@ -983,6 +1006,10 @@ controls.eulaAccepted?.addEventListener("change", () => {
 
 wizardEulaAccepted?.addEventListener("change", () => {
   syncEulaCheckboxes(wizardEulaAccepted);
+});
+
+controls.sttProvider?.addEventListener("change", () => {
+  syncSttEndpointForProvider();
 });
 
 liveMonitorEnabled?.addEventListener("change", async () => {

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -90,6 +90,7 @@
                 <option value="mock">Mock STT</option>
                 <option value="whispercpp">Whisper.cpp (custom endpoint)</option>
                 <option value="deepgram">Deepgram</option>
+                <option value="openai-whisper">OpenAI Whisper (cloud)</option>
               </select>
             </label>
             <label>STT endpoint <input id="sttEndpoint" type="text" value="http://127.0.0.1:7778/stt" /></label>

--- a/src/server.ts
+++ b/src/server.ts
@@ -126,13 +126,14 @@ app.post("/api/start", (_req, res) => {
 
   const cloudInference = config.inferenceMode === "openai" || config.inferenceMode === "groq" || config.inferenceMode === "mock-cloud";
   const cloudTts = config.ttsEnabled && config.ttsMode === "cloud";
+  const cloudStt = config.capture.useRealCapture && config.capture.sttProvider === "openai-whisper";
   const hasCloudKey = secretStore.diagnostics().hasCloudKey;
 
-  if ((cloudInference || cloudTts) && !hasCloudKey) {
+  if ((cloudInference || cloudTts || cloudStt) && !hasCloudKey) {
     res.status(400).json({
       ok: false,
-      error: "Cloud mode selected without API key. Save Cloud API key or switch inference/TTS to local.",
-      missing: { cloudInference, cloudTts }
+      error: "Cloud mode selected without API key. Save Cloud API key or switch inference/TTS/STT to local.",
+      missing: { cloudInference, cloudTts, cloudStt }
     });
     return;
   }
@@ -254,8 +255,10 @@ app.get("/api/status", (_req, res) => {
       configuredProvider: config.capture.sttProvider,
       engineProvider: sharedSttEngine.state().provider,
       deepgramKeyPresent: Boolean(process.env.STREAMSIM_DEEPGRAM_API_KEY),
+      cloudKeyPresent: secretStore.diagnostics().hasCloudKey,
       endpoint: config.capture.sttEndpoint,
-      localConfigured: config.capture.sttProvider === "local-whisper"
+      localConfigured: config.capture.sttProvider === "local-whisper",
+      openAiWhisperConfigured: config.capture.sttProvider === "openai-whisper"
     },
     onboardingComplete,
     bootDiagnostics: {

--- a/src/services/readinessChecks.ts
+++ b/src/services/readinessChecks.ts
@@ -22,7 +22,7 @@ async function checkNetwork(config: SimulationConfig): Promise<ReadinessCheck> {
   }
 }
 
-function checkDevice(config: SimulationConfig): ReadinessCheck {
+function checkDevice(config: SimulationConfig, hasCloudKey: boolean): ReadinessCheck {
   const errors: string[] = [];
   try {
     new URL(config.capture.sttEndpoint);
@@ -37,6 +37,10 @@ function checkDevice(config: SimulationConfig): ReadinessCheck {
 
   if (config.capture.useRealCapture && config.capture.sttProvider === "deepgram" && !process.env.STREAMSIM_DEEPGRAM_API_KEY) {
     errors.push("Deepgram STT selected but STREAMSIM_DEEPGRAM_API_KEY is missing.");
+  }
+
+  if (config.capture.useRealCapture && config.capture.sttProvider === "openai-whisper" && !hasCloudKey) {
+    errors.push("OpenAI Whisper STT selected but no cloud API key is stored.");
   }
 
   if (config.capture.useRealCapture && (config.capture.sttProvider === "whispercpp" || config.capture.sttProvider === "local-whisper") && !config.capture.sttEndpoint.startsWith("http")) {
@@ -98,7 +102,7 @@ async function checkSidecar(config: SimulationConfig, sidecar: SidecarManager): 
 }
 
 export async function runReadinessChecks(config: SimulationConfig, sidecar = new SidecarManager(), hasCloudKey = false): Promise<{ checks: ReadinessCheck[]; ready: boolean }> {
-  const checks = [checkDevice(config), checkCredentials(config, hasCloudKey), await checkNetwork(config), await checkSidecar(config, sidecar)];
+  const checks = [checkDevice(config, hasCloudKey), checkCredentials(config, hasCloudKey), await checkNetwork(config), await checkSidecar(config, sidecar)];
   const ready = checks.filter((check) => check.severity === "blocking").every((check) => check.ok);
   return { checks, ready };
 }


### PR DESCRIPTION
### Motivation
- Mic/STT probe failures were surfacing unhelpful "fetch failed" messages and the system lacked a cloud STT option that uses the same stored cloud API key as the OpenAI chat generator.
- Provide a cloud Whisper STT path and clearer provider-aware error handling so mic verification and real-capture flows are more reliable and debuggable.

### Description
- Added a new STT provider kind `openai-whisper` and implemented `OpenAiWhisperBackend` that posts audio to an OpenAI transcription endpoint using `SecretStore` for the same cloud API key used by cloud inference. (src/capture/sttEngine.ts)
- Hardened STT backend fetch calls for Whisper/Deepgram with try/catch to yield provider/context-rich error messages instead of generic failures. (src/capture/sttEngine.ts)
- Centralized STT default endpoints and added logic to resolve provider-specific endpoints (avoids accidentally using the local default when selecting cloud STT). (src/capture/sttEngine.ts, src/public/app.js)
- Extended types, runtime sanitization, and migration logic to recognize and persist `openai-whisper` as a valid STT provider. (src/core/types.ts, src/config/runtimeConfig.ts, src/config/configMigrations.ts)
- Added readiness/start gating for OpenAI Whisper so the app blocks start when cloud STT is selected but no cloud API key is stored, and surfaced cloud-key presence in `/api/status`. (src/services/readinessChecks.ts, src/server.ts)
- Updated control center UI to include an "OpenAI Whisper (cloud)" STT option, provide provider-aware default endpoints, and auto-sync the STT endpoint when switching providers; STT health summaries now account for missing cloud keys for OpenAI Whisper. (src/public/index.html, src/public/app.js)

### Testing
- Built the project with `npm run build` and the TypeScript compilation completed successfully. (passed)
- Ran the test suite with `npm test` (Vitest), where all test files and assertions passed: 14 test files, 54 tests all passing. (passed)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6a79000048326bb7201b5fa06fe80)