### PR TITLE
Improve mic STT probe chunking for sentence-level capture

### DIFF
--- a/src/public/app.js
+++ b/src/public/app.js
@@ -35,9 +35,9 @@ let latestDeviceVerification = {
   cameraFailureReason: null
 };
 
-const MIC_CHECK_PROBE_SECONDS = 0.6;
-const MIC_CHECK_BUFFER_SECONDS = 1.8;
-const MIC_CHECK_MIN_SAMPLES = 2000;
+const MIC_CHECK_PROBE_SECONDS = 3.5;
+const MIC_CHECK_BUFFER_SECONDS = 8;
+const MIC_CHECK_MIN_SAMPLES = 12000;
 const CAMERA_FRAME_CONFIRM_TIMEOUT_MS = 3000;
 const STT_DEFAULT_ENDPOINTS = {
   "local-whisper": "http://127.0.0.1:7778/stt",
@@ -288,7 +288,7 @@ async function startMicVerificationCheck() {
   processor.onaudioprocess = (event) => {
     const input = event.inputBuffer.getChannelData(0);
     micCheckQueuedPcm.push(...input);
-    const maxSamples = Math.floor((micCheckAudioContext?.sampleRate ?? 44100) * 4);
+    const maxSamples = Math.floor((micCheckAudioContext?.sampleRate ?? 44100) * MIC_CHECK_BUFFER_SECONDS);
     if (micCheckQueuedPcm.length > maxSamples) {
       micCheckQueuedPcm = micCheckQueuedPcm.slice(-maxSamples);
     }
@@ -308,9 +308,9 @@ async function startMicVerificationCheck() {
 
   micCheckDataInterval = setInterval(() => {
     void probeSttFromMicChunk();
-  }, 1800);
+  }, 3200);
 
-  setCaptionStatus("Mic stream active. Speak a short phrase to verify STT transcript.", "ok");
+  setCaptionStatus("Mic stream active. Speak naturally for a few seconds to verify sentence-level STT.", "ok");
   setCaptionPreview(latestCaptionText || "Listening for speech...");
 }
 


### PR DESCRIPTION
### Motivation

- The microphone verification was sending very short STT probes, causing the STT to capture only single words instead of multi-word/sentence context. This change aims to give the STT longer, more meaningful audio windows.

### Description

- Increase `MIC_CHECK_PROBE_SECONDS` from `0.6` to `3.5` to send longer probe clips to the STT backend in `src/public/app.js`.
- Expand `MIC_CHECK_BUFFER_SECONDS` from `1.8` to `8` and raise `MIC_CHECK_MIN_SAMPLES` from `2000` to `12000` so the client retains more mic buffer before probing.
- Reduce probe cadence by changing the periodic probe from `1800`ms to `3200`ms so the client sends fewer, larger slices instead of many tiny requests.
- Align in-memory queue trimming to use `MIC_CHECK_BUFFER_SECONDS` (instead of a hardcoded `4`) and update UI guidance text to prompt users to speak naturally for a few seconds.

### Testing

- Ran the test suite with `npm test`; all automated tests passed (14 test files, 54 tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6aa94c8408326a879303a2354fadf)