### PR TITLE
Handle OpenAI chat `message.content` parts so cloud inference emits messages

### DIFF
--- a/src/llm/realInferenceProvider.ts
+++ b/src/llm/realInferenceProvider.ts
@@ -47,6 +47,56 @@ async function parseProviderError(response: Response): Promise<string> {
   return [detail, extras].filter(Boolean).join(" | ");
 }
 
+type ProviderResponseShape = {
+  response?: string;
+  text?: string;
+  output_text?: string;
+  content?: Array<{ type?: string; text?: string | { value?: string } }>;
+  choices?: Array<{
+    text?: string;
+    message?: {
+      content?: string | Array<{ type?: string; text?: string | { value?: string } }>;
+    };
+  }>;
+};
+
+function extractTextFromContentParts(
+  parts: Array<{ type?: string; text?: string | { value?: string } }> | undefined
+): string | null {
+  if (!Array.isArray(parts) || parts.length === 0) return null;
+  const joined = parts
+    .map((part) => {
+      if (typeof part?.text === "string") return part.text;
+      if (part?.text && typeof part.text === "object" && typeof part.text.value === "string") return part.text.value;
+      return "";
+    })
+    .filter(Boolean)
+    .join("\n")
+    .trim();
+  return joined.length ? joined : null;
+}
+
+function extractProviderText(data: ProviderResponseShape): string {
+  const chatMessageContent = data.choices?.[0]?.message?.content;
+  if (typeof chatMessageContent === "string" && chatMessageContent.trim()) return chatMessageContent;
+  if (Array.isArray(chatMessageContent)) {
+    const fromParts = extractTextFromContentParts(chatMessageContent);
+    if (fromParts) return fromParts;
+  }
+
+  const choiceText = data.choices?.[0]?.text;
+  if (typeof choiceText === "string" && choiceText.trim()) return choiceText;
+
+  if (typeof data.output_text === "string" && data.output_text.trim()) return data.output_text;
+  if (typeof data.response === "string" && data.response.trim()) return data.response;
+  if (typeof data.text === "string" && data.text.trim()) return data.text;
+
+  const topLevelContent = extractTextFromContentParts(data.content);
+  if (topLevelContent) return topLevelContent;
+
+  return "";
+}
+
 export class HybridInferenceProvider implements InferenceProvider {
   private readonly mockProvider = new MockInferenceProvider();
   private readonly secretStore = new SecretStore();
@@ -143,8 +193,8 @@ export class HybridInferenceProvider implements InferenceProvider {
       throw new Error(`Local provider failed (${response.status})`);
     }
 
-    const data = (await response.json()) as { response?: string; text?: string; choices?: Array<{ message?: { content?: string } }> };
-    return data.response ?? data.text ?? data.choices?.[0]?.message?.content ?? "";
+    const data = (await response.json()) as ProviderResponseShape;
+    return extractProviderText(data);
   }
 
   private async generateCloud(payload: PromptPayload, config: SimulationConfig): Promise<string> {
@@ -181,12 +231,8 @@ export class HybridInferenceProvider implements InferenceProvider {
       throw new Error(`Cloud provider failed (${response.status})${detail ? `: ${detail}` : ""}`);
     }
 
-    const data = (await response.json()) as {
-      choices?: Array<{ message?: { content?: string } }>;
-      output_text?: string;
-    };
-
-    return data.choices?.[0]?.message?.content ?? data.output_text ?? "";
+    const data = (await response.json()) as ProviderResponseShape;
+    return extractProviderText(data);
   }
 
   private healthEndpointForCloud(config: SimulationConfig): string {

--- a/tests/integrationRouting.test.ts
+++ b/tests/integrationRouting.test.ts
@@ -198,6 +198,43 @@ describe("hybrid routing and failover", () => {
     await expect(groqProvider.generate(payload, config)).resolves.toContain("messages");
     await server.close();
   });
+
+  it("accepts chat-completions content parts payloads used by newer OpenAI-compatible SDKs", async () => {
+    process.env.STREAMSIM_CLOUD_API_KEY = "abc123";
+    const server = await withTestServer((req, res) => {
+      if (req.method !== "POST") {
+        res.writeHead(404);
+        res.end();
+        return;
+      }
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          choices: [
+            {
+              message: {
+                content: [{ type: "text", text: '{"messages":[{"username":"newapi","text":"hello","emotes":[]}]}' }]
+              }
+            }
+          ]
+        })
+      );
+    });
+
+    const provider = new HybridInferenceProvider("openai");
+    const config = { ...defaultConfig, provider: { ...defaultConfig.provider, cloudEndpoint: server.url, cloudModel: "x" } };
+    const payload = {
+      persona: "supportive" as const,
+      bias: "agree" as const,
+      emoteOnly: false,
+      viewerCount: 10,
+      requestedMessageCount: 1,
+      context: { transcript: "switch now", tone: { volumeRms: 0.5, paceWpm: 140 }, visionTags: ["monitor"], timestamp: new Date().toISOString() }
+    };
+
+    await expect(provider.generate(payload, config)).resolves.toContain('"username":"newapi"');
+    await server.close();
+  });
 });
 
 describe("device capture pipeline + security + observability schema", () => {


### PR DESCRIPTION
### Motivation
- Cloud inference in OpenAI-compatible modes sometimes returns assistant content as an array of typed content parts instead of a single string, which previously produced empty outputs and led to silent ticks with no chatters emitted. 
- The change ensures the provider robustly extracts text from multiple response shapes so live simulation continues when STT/camera are healthy.

### Description
- Added a `ProviderResponseShape` type and an `extractProviderText` helper that normalizes output across shapes like `choices[0].message.content` arrays, `choices[].text`, `output_text`, `response`, and `text`.  
- Implemented `extractTextFromContentParts` to flatten typed content parts (e.g., `{ type: "text", text: { value: "..." } }`) into a contiguous string.  
- Updated both local and cloud code paths in `HybridInferenceProvider` to use the shared extraction helper instead of assuming a single string field.  
- Added an integration test that simulates newer OpenAI-compatible `message.content` arrays and verifies the provider returns parseable message JSON.

### Testing
- Ran `npm test -- tests/integrationRouting.test.ts`, which passed (10 tests) and returned success.  
- Ran `npm run build` (`tsc`), which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6ad89fa188326bd1e8fee42939c6e)