### PR TITLE
Update default cloud model to GPT-5 nano

### DIFF
--- a/src/config/runtimeConfig.ts
+++ b/src/config/runtimeConfig.ts
@@ -32,7 +32,7 @@ export const defaultConfig: SimulationConfig = {
     localEndpoint: "http://127.0.0.1:11434",
     localModel: "llama3.1:8b-instruct-q4_K_M",
     cloudEndpoint: "https://api.openai.com/v1/chat/completions",
-    cloudModel: "gpt-4o-mini",
+    cloudModel: "gpt-5-nano",
     requestTimeoutMs: 7000,
     maxRetries: 2
   },

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -70,7 +70,7 @@
             <label>Local endpoint <input id="localEndpoint" type="text" value="http://127.0.0.1:11434" /></label>
             <label>Local model <input id="localModel" type="text" value="llama3.1:8b-instruct-q4_K_M" /></label>
             <label>Cloud endpoint <input id="cloudEndpoint" type="text" value="https://api.openai.com/v1/chat/completions" /></label>
-            <label>Cloud model <input id="cloudModel" type="text" value="gpt-4o-mini" /></label>
+            <label>Cloud model <input id="cloudModel" type="text" value="gpt-5-nano" /></label>
             <label>Request timeout ms <input id="requestTimeoutMs" type="number" min="1000" max="30000" value="7000" /></label>
             <label>Max retries <input id="maxRetries" type="number" min="0" max="5" value="2" /></label>
             <label><input id="ttsEnabled" type="checkbox" checked /> TTS Enabled</label>


### PR DESCRIPTION
### Motivation
- Prefer the newer GPT-5 nano as the default cloud LLM for new simulations so runtime and UI defaults reflect the intended cloud inference target.

### Description
- Updated the default cloud model from `gpt-4o-mini` to `gpt-5-nano` in `src/config/runtimeConfig.ts` and updated the Control Center UI default in `src/public/index.html` to match.

### Testing
- Ran `npm test -- tests/uiRuntimeVerification.test.ts` and the test file passed (4/4 tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6c36775e88326bc6bcd74e6c6ee12)