### PR TITLE
Prioritize live streamer transcript in chat generation

### DIFF
--- a/src/capture/captureProviders.ts
+++ b/src/capture/captureProviders.ts
@@ -17,15 +17,8 @@ export class MockCaptureProvider implements CaptureProvider {
 }
 
 export class DeviceCaptureProvider implements CaptureProvider {
-  private readonly fallback = new MockCaptureProvider();
-
   public async getContext(config: SimulationConfig): Promise<StreamContext> {
-    const context = sharedDeviceCapturePipeline.getContext(config);
-    if (!context.transcript) {
-      return this.fallback.getContext(config);
-    }
-
-    return context;
+    return sharedDeviceCapturePipeline.getContext(config);
   }
 }
 

--- a/src/llm/realInferenceProvider.ts
+++ b/src/llm/realInferenceProvider.ts
@@ -97,6 +97,21 @@ function extractProviderText(data: ProviderResponseShape): string {
   return "";
 }
 
+function systemPromptForPayload(payload: PromptPayload): string {
+  const transcript = payload.context.transcript.trim();
+  const transcriptDirective = transcript
+    ? `Highest priority: react directly to the streamer's latest words from context.transcript ("${transcript.slice(0, 220)}").`
+    : "No transcript text is available right now; infer likely chat reactions from tone + vision tags without inventing quoted speech.";
+
+  return [
+    'Return strict JSON only: {"messages":[{"text":"string","emotes":["string"],"donationCents":number?,"ttsText":"string?"}]}. Never include usernames.',
+    "You are simulating a live audience reacting to the streamer in real time (not a generic standalone chat).",
+    transcriptDirective,
+    "Treat context.transcript as more important than persona flavor text when they conflict.",
+    "Reference concrete details from context (transcript/tone/vision) in at least half of the messages."
+  ].join(" ");
+}
+
 export class HybridInferenceProvider implements InferenceProvider {
   private readonly mockProvider = new MockInferenceProvider();
   private readonly secretStore = new SecretStore();
@@ -172,7 +187,7 @@ export class HybridInferenceProvider implements InferenceProvider {
           model: config.provider.localModel,
           temperature: 0.8,
           messages: [
-            { role: "system", content: 'Return strict JSON only: {"messages":[{"text":"string","emotes":["string"],"donationCents":number?,"ttsText":"string?"}]}. Never include usernames.' },
+            { role: "system", content: systemPromptForPayload(payload) },
             { role: "user", content: JSON.stringify(payload) }
           ]
         }
@@ -216,7 +231,7 @@ export class HybridInferenceProvider implements InferenceProvider {
           model: config.provider.cloudModel,
           temperature: 0.8,
           messages: [
-            { role: "system", content: 'Return strict JSON only: {"messages":[{"text":"string","emotes":["string"],"donationCents":number?,"ttsText":"string?"}]}. Never include usernames.' },
+            { role: "system", content: systemPromptForPayload(payload) },
             { role: "user", content: JSON.stringify(payload) }
           ]
         })


### PR DESCRIPTION
### Motivation
- Cloud/local LLM outputs were coming across as generic and not reliably reacting to live STT/camera input, so the live transcript needs higher priority in prompts.
- The device capture path could replace real pipeline context with mock context when the transcript was briefly empty, which reduces reactivity to the streamer.

### Description
- Remove the mock fallback in `DeviceCaptureProvider` so `sharedDeviceCapturePipeline.getContext(config)` is always forwarded to inference unchanged. 
- Add `systemPromptForPayload(payload)` in `src/llm/realInferenceProvider.ts` that explicitly prioritizes `context.transcript`, instructs the model to react to the streamer in real time, and requires concrete context references. 
- Use the new `systemPromptForPayload` for both LM Studio (`/v1/chat/completions`) and cloud OpenAI/Groq chat-completions payloads. 
- Keep JSON-only response enforcement while strengthening behavioral directions (treat transcript as higher priority than persona when conflicts arise). 

### Testing
- Attempted `npm test -- --runInBand tests/integrationRouting.test.ts tests/hardeningFlows.test.ts tests/productionHardening.test.ts` which failed due to Vitest not recognizing `--runInBand` (expected CLI option mismatch). 
- Ran `npm test -- tests/integrationRouting.test.ts tests/hardeningFlows.test.ts tests/productionHardening.test.ts` and all targeted tests passed (3 files, 27 tests, all succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6c5aa19b08326b24e05234c64830c)