### PR TITLE
Harden reliability paths and prevent silent simulation failures

### DIFF
--- a/src/pipeline/outputParser.ts
+++ b/src/pipeline/outputParser.ts
@@ -2,6 +2,7 @@ import { ChatMessage } from "../core/types.js";
 
 export type MalformedOutputClass = "empty" | "no_json_object" | "json_syntax" | "missing_messages" | "invalid_message_schema";
 export type RecoveryAction = "repair" | "regenerate" | "drop";
+const MAX_INFERENCE_OUTPUT_CHARS = 250_000;
 
 function coerceMessage(raw: unknown): ChatMessage | null {
   if (typeof raw !== "object" || raw === null) return null;
@@ -33,6 +34,12 @@ export function repairInferenceOutput(raw: string): string {
   return raw.trim().replace(/^```json\s*/i, "").replace(/^###json\s*/i, "").replace(/\s*```$/i, "").replace(/\s*###$/i, "");
 }
 
+function sanitizeRawOutput(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) return "";
+  return trimmed.length > MAX_INFERENCE_OUTPUT_CHARS ? trimmed.slice(0, MAX_INFERENCE_OUTPUT_CHARS) : trimmed;
+}
+
 function extractLikelyJsonObject(raw: string): string {
   const start = raw.indexOf("{");
   const end = raw.lastIndexOf("}");
@@ -43,7 +50,7 @@ function extractLikelyJsonObject(raw: string): string {
 }
 
 export function classifyMalformedOutput(raw: string): MalformedOutputClass {
-  const trimmed = raw.trim();
+  const trimmed = sanitizeRawOutput(raw);
   if (!trimmed) return "empty";
 
   const repaired = repairInferenceOutput(trimmed);
@@ -64,11 +71,11 @@ export function classifyMalformedOutput(raw: string): MalformedOutputClass {
   const parsed = data.messages.map(coerceMessage).filter((message): message is ChatMessage => Boolean(message));
   if (!parsed.length) return "invalid_message_schema";
 
-  return "missing_messages";
+  return "json_syntax";
 }
 
 function parsePayload(raw: string): Record<string, unknown> {
-  const repaired = repairInferenceOutput(raw);
+  const repaired = repairInferenceOutput(sanitizeRawOutput(raw));
   try {
     return JSON.parse(repaired) as Record<string, unknown>;
   } catch {

--- a/src/public/app.js
+++ b/src/public/app.js
@@ -22,10 +22,14 @@ let micCheckStream = null;
 let micCheckAudioContext = null;
 let micCheckMeterInterval = null;
 let micCheckDataInterval = null;
+let micCheckSource = null;
+let micCheckAnalyser = null;
+let micCheckProcessor = null;
 let micCheckQueuedPcm = [];
 let micCheckProbeInFlight = false;
 let latestCaptionText = "";
 let latestStatusPayload = null;
+let simulationActionInFlight = false;
 let latestDeviceVerification = {
   micPermission: false,
   cameraPermission: false,
@@ -249,6 +253,19 @@ function stopMicVerificationCheck() {
     clearInterval(micCheckDataInterval);
     micCheckDataInterval = null;
   }
+  if (micCheckProcessor) {
+    micCheckProcessor.onaudioprocess = null;
+    micCheckProcessor.disconnect();
+    micCheckProcessor = null;
+  }
+  if (micCheckAnalyser) {
+    micCheckAnalyser.disconnect();
+    micCheckAnalyser = null;
+  }
+  if (micCheckSource) {
+    micCheckSource.disconnect();
+    micCheckSource = null;
+  }
   if (micCheckAudioContext) {
     void micCheckAudioContext.close();
     micCheckAudioContext = null;
@@ -281,10 +298,13 @@ async function startMicVerificationCheck() {
   const analyser = micCheckAudioContext.createAnalyser();
   analyser.fftSize = 256;
   source.connect(analyser);
+  micCheckSource = source;
+  micCheckAnalyser = analyser;
 
   const processor = micCheckAudioContext.createScriptProcessor(4096, 1, 1);
   source.connect(processor);
   processor.connect(micCheckAudioContext.destination);
+  micCheckProcessor = processor;
   processor.onaudioprocess = (event) => {
     const input = event.inputBuffer.getChannelData(0);
     micCheckQueuedPcm.push(...input);
@@ -372,6 +392,12 @@ async function startLiveMonitor() {
 function setPending(button, isPending) {
   if (!button) return;
   button.disabled = isPending;
+}
+
+function setSimulationActionPending(isPending) {
+  simulationActionInFlight = isPending;
+  if (startBtn) startBtn.disabled = isPending;
+  if (stopBtn) stopBtn.disabled = isPending;
 }
 
 async function runAction({ button, pendingText, successText, onRun }) {
@@ -793,6 +819,8 @@ saveBtn.addEventListener("click", async () => {
 });
 
 startBtn.addEventListener("click", async () => {
+  if (simulationActionInFlight) return;
+  setSimulationActionPending(true);
   await runAction({
     button: startBtn,
     pendingText: "Starting simulation...",
@@ -814,15 +842,19 @@ startBtn.addEventListener("click", async () => {
       return post("/api/start");
     }
   });
+  setSimulationActionPending(false);
 });
 
 stopBtn.addEventListener("click", async () => {
+  if (simulationActionInFlight) return;
+  setSimulationActionPending(true);
   await runAction({
     button: stopBtn,
     pendingText: "Stopping simulation...",
     successText: "Simulation stopped.",
     onRun: () => post("/api/stop")
   });
+  setSimulationActionPending(false);
 });
 
 rebindBtn.addEventListener("click", async () => {

--- a/src/services/simulationOrchestrator.ts
+++ b/src/services/simulationOrchestrator.ts
@@ -11,6 +11,7 @@ import { SidecarManager } from "./sidecarManager.js";
 import { SpoolingEngine } from "./spoolingEngine.js";
 import { MockInferenceProvider } from "../llm/mockInferenceProvider.js";
 import { IdentityManager } from "./identityManager.js";
+import { sharedDeviceCapturePipeline } from "../capture/deviceCapturePipeline.js";
 
 export class SimulationOrchestrator {
   private readonly spooler = new SpoolingEngine();
@@ -62,6 +63,9 @@ export class SimulationOrchestrator {
       clearTimeout(this.ttsWatchdogTimer);
       this.ttsWatchdogTimer = null;
     }
+    this.audioState.stopTts();
+    sharedSttEngine.resume();
+    sharedDeviceCapturePipeline.reset();
   }
 
   public cancelSidecarPull(): void {
@@ -115,164 +119,177 @@ export class SimulationOrchestrator {
   private async loop(): Promise<void> {
     if (!this.running) return;
 
-    const config = this.getConfig();
-    const captureProvider = createCaptureProvider(config);
-    const provider = createInferenceProvider(config.inferenceMode);
-    const startedAt = Date.now();
+    let timing = this.spooler.nextDelayMs(this.getConfig(), { volumeRms: 0.2, paceWpm: 110 });
 
-    if (!config.compliance.eulaAccepted) {
-      this.emitMeta({ warning: "EULA must be accepted before simulation starts." });
-      this.running = false;
-      return;
-    }
+    try {
+      const config = this.getConfig();
+      const captureProvider = createCaptureProvider(config);
+      const provider = createInferenceProvider(config.inferenceMode);
+      const startedAt = Date.now();
 
-    const sidecarStatus = await this.sidecar.ensureReady(config);
-    if (!sidecarStatus.ready) {
-      this.emitMeta({ warning: sidecarStatus.details, fallbackSuggested: sidecarStatus.fallbackSuggested, blocked: false, recovery: sidecarStatus.uxAction });
-      this.obs.log("sidecar_status", { sidecarStatus: sidecarStatus.phase, progress: sidecarStatus.progress });
-    }
-
-    const validation = provider.validateConfig(config);
-    if (!validation.ok) {
-      this.emitMeta({ warnings: validation.errors, blocked: false });
-      this.setAiStatus({ state: "degraded", providerHealth: "degraded", detail: validation.errors.join(" | ") });
-    }
-
-    const health = await provider.healthCheck(config);
-    if (!health.ok) {
-      this.emitMeta({ warnings: [`Provider unhealthy: ${health.details}`], blocked: false });
-      this.setAiStatus({ state: "degraded", providerHealth: "degraded", detail: `Provider unhealthy: ${health.details}` });
-    } else {
-      this.setAiStatus({ providerHealth: "ok", detail: health.details });
-    }
-
-    const captureStarted = Date.now();
-    const context = await captureProvider.getContext(config);
-    const captureLatencyMs = Date.now() - captureStarted;
-
-    const timing = this.spooler.nextDelayMs(config, context.tone);
-
-    if (this.audioState.canListenToMic()) {
-      sharedSttEngine.resume();
-      const payload = buildPromptPayload(config, context);
-      let messages: ChatMessage[] = [];
-
-      const inferenceStarted = Date.now();
-      this.setAiStatus({ state: "running", fallbackMode: null, detail: `Generating via ${config.inferenceMode}.` });
-      try {
-        const rawOutput = await provider.generate(payload, config, (attempt, reason) => {
-          const recovery = this.cloudRecoveryMeta(attempt, config.provider.maxRetries, reason);
-          this.emitMeta({ warnings: [recovery.message], cloudRecovery: recovery.phase, blocked: recovery.blocking });
-        });
-        try {
-          messages = this.hydrateMessages(parseInferenceOutput(rawOutput), "real-inference");
-        } catch (parseError) {
-          const malformedClass = classifyMalformedOutput(rawOutput);
-          const action = recommendedRecoveryAction(malformedClass);
-          this.obs.log("malformed_json_counter", { malformedClass, action, stage: "first_pass" });
-
-          if ((action === "repair" || action === "regenerate") && config.safety.regenerateOnMalformedJson) {
-            const retryOutput = await provider.generate(payload, config);
-            messages = this.hydrateMessages(parseInferenceOutput(retryOutput), "real-inference");
-            this.emitMeta({ warnings: [`Malformed inference JSON recovered via ${action} fallback.`], blocked: false, malformedClass, action });
-            this.obs.log("malformed_json_counter", { malformedClass, action, stage: "recovered" });
-          } else {
-            this.emitMeta({ warning: `Dropped malformed output (${malformedClass}).`, blocked: false, malformedClass, action: "drop" });
-            this.obs.log("malformed_json_counter", { malformedClass, action: "drop", stage: "dropped" });
-            if (!config.safety.dropOnParseFailure) throw parseError;
-          }
-        }
-      } catch (error) {
-        const reason = (error as Error).message;
-        this.obs.log("reliability_recovery", { ok: false, reason });
-        this.setAiStatus({ state: "degraded", providerHealth: "degraded", detail: reason });
-
-        try {
-          const fallbackOutput = await this.mockProvider.generate(payload, { ...config, inferenceMode: "mock-local" });
-          messages = this.hydrateMessages(parseInferenceOutput(fallbackOutput), "fallback-mock");
-          this.setAiStatus({ state: "degraded", providerHealth: "degraded", fallbackMode: "mock-local", detail: `Primary inference failed; mock fallback active: ${reason}` });
-          this.emitMeta({
-            warnings: [reason, "Fallback engaged: mock-local"],
-            dropped: false,
-            blocked: false,
-            cloudRecovery: "degraded",
-            source: "fallback-mock",
-            provider: config.inferenceMode,
-            timeoutMs: config.provider.requestTimeoutMs,
-            retries: config.provider.maxRetries
-          });
-        } catch (fallbackError) {
-          const fallbackReason = (fallbackError as Error).message;
-          this.setAiStatus({ state: "error", providerHealth: "degraded", fallbackMode: null, detail: `Fallback failed: ${fallbackReason}` });
-          if (config.safety.dropOnParseFailure) {
-            this.emitMeta({ warning: `${reason} | fallback failed: ${fallbackReason}`, dropped: true, blocked: false, cloudRecovery: "degraded" });
-          }
-        }
+      if (!config.compliance.eulaAccepted) {
+        this.emitMeta({ warning: "EULA must be accepted before simulation starts." });
+        this.running = false;
+        return;
       }
-      const inferenceLatencyMs = Date.now() - inferenceStarted;
 
-      const safety = applySafetyPolicy(messages, config);
-      const safeMessages = safety.safeMessages;
+      const sidecarStatus = await this.sidecar.ensureReady(config);
+      if (!sidecarStatus.ready) {
+        this.emitMeta({ warning: sidecarStatus.details, fallbackSuggested: sidecarStatus.fallbackSuggested, blocked: false, recovery: sidecarStatus.uxAction });
+        this.obs.log("sidecar_status", { sidecarStatus: sidecarStatus.phase, progress: sidecarStatus.progress });
+      }
 
-      safeMessages.forEach((msg) => {
-        if (config.ttsEnabled && config.ttsMode !== "off" && msg.ttsText) {
-          this.audioState.startTts();
-          sharedSttEngine.pause();
-          setTimeout(() => {
-            this.audioState.stopTts();
-            sharedSttEngine.resume();
-          }, 1400);
-          if (this.ttsWatchdogTimer) clearTimeout(this.ttsWatchdogTimer);
-          this.ttsWatchdogTimer = setTimeout(() => {
-            const forced = this.audioState.forceResetIfStale(2800);
-            if (forced) {
-              sharedSttEngine.resume();
-              this.emitMeta({ warnings: ["TTS watchdog forced stale-state reset."], blocked: false });
+      const validation = provider.validateConfig(config);
+      if (!validation.ok) {
+        this.emitMeta({ warnings: validation.errors, blocked: false });
+        this.setAiStatus({ state: "degraded", providerHealth: "degraded", detail: validation.errors.join(" | ") });
+      }
+
+      const health = await provider.healthCheck(config);
+      if (!health.ok) {
+        this.emitMeta({ warnings: [`Provider unhealthy: ${health.details}`], blocked: false });
+        this.setAiStatus({ state: "degraded", providerHealth: "degraded", detail: `Provider unhealthy: ${health.details}` });
+      } else {
+        this.setAiStatus({ providerHealth: "ok", detail: health.details });
+      }
+
+      const captureStarted = Date.now();
+      const context = await captureProvider.getContext(config);
+      const captureLatencyMs = Date.now() - captureStarted;
+
+      timing = this.spooler.nextDelayMs(config, context.tone);
+
+      if (this.audioState.canListenToMic()) {
+        sharedSttEngine.resume();
+        const payload = buildPromptPayload(config, context);
+        let messages: ChatMessage[] = [];
+
+        const inferenceStarted = Date.now();
+        this.setAiStatus({ state: "running", fallbackMode: null, detail: `Generating via ${config.inferenceMode}.` });
+        try {
+          const rawOutput = await provider.generate(payload, config, (attempt, reason) => {
+            const recovery = this.cloudRecoveryMeta(attempt, config.provider.maxRetries, reason);
+            this.emitMeta({ warnings: [recovery.message], cloudRecovery: recovery.phase, blocked: recovery.blocking });
+          });
+          try {
+            messages = this.hydrateMessages(parseInferenceOutput(rawOutput), "real-inference");
+          } catch (parseError) {
+            const malformedClass = classifyMalformedOutput(rawOutput);
+            const action = recommendedRecoveryAction(malformedClass);
+            this.obs.log("malformed_json_counter", { malformedClass, action, stage: "first_pass" });
+
+            if ((action === "repair" || action === "regenerate") && config.safety.regenerateOnMalformedJson) {
+              const retryOutput = await provider.generate(payload, config);
+              messages = this.hydrateMessages(parseInferenceOutput(retryOutput), "real-inference");
+              this.emitMeta({ warnings: [`Malformed inference JSON recovered via ${action} fallback.`], blocked: false, malformedClass, action });
+              this.obs.log("malformed_json_counter", { malformedClass, action, stage: "recovered" });
+            } else {
+              this.emitMeta({ warning: `Dropped malformed output (${malformedClass}).`, blocked: false, malformedClass, action: "drop" });
+              this.obs.log("malformed_json_counter", { malformedClass, action: "drop", stage: "dropped" });
+              if (!config.safety.dropOnParseFailure) throw parseError;
             }
-          }, 3200);
-        }
-      });
+          }
+        } catch (error) {
+          const reason = (error as Error).message;
+          this.obs.log("reliability_recovery", { ok: false, reason });
+          this.setAiStatus({ state: "degraded", providerHealth: "degraded", detail: reason });
 
-      this.emitMessages(safeMessages);
-      const latencyMs = Date.now() - startedAt;
-      this.obs.log("pipeline_tick", {
-        inferenceMode: config.inferenceMode,
-        requestedMessageCount: payload.requestedMessageCount,
-        emittedCount: safeMessages.length,
-        latencyMs,
-        captureLatencyMs,
-        inferenceLatencyMs,
-        targetDelayMs: timing.actualDelayMs,
-        jankMs: Math.max(0, latencyMs - timing.actualDelayMs)
-      });
-
-      this.emitMeta({
-        context,
-        timing,
-        audioState: this.getAudioState(),
-        inferenceMode: config.inferenceMode,
-        providerSource: safeMessages[0]?.source ?? "unknown",
-        requestedMessageCount: payload.requestedMessageCount,
-        latencyMs,
-        captureLatencyMs,
-        inferenceLatencyMs,
-        safety: {
-          dropPolicy: config.safety.dropPolicy,
-          droppedCount: safety.droppedCount,
-          queueSize: safety.queueMessages.length
-        },
-        queueMessages: safety.queueMessages,
-        slo: {
-          targetMs: 3000,
-          withinTarget: latencyMs <= 3000
-        },
-        ai: this.getAiStatus(),
-        providerDiagnostics: {
-          timeoutMs: config.provider.requestTimeoutMs,
-          retries: config.provider.maxRetries,
-          fallbackActive: this.aiStatus.fallbackMode !== null
+          try {
+            const fallbackOutput = await this.mockProvider.generate(payload, { ...config, inferenceMode: "mock-local" });
+            messages = this.hydrateMessages(parseInferenceOutput(fallbackOutput), "fallback-mock");
+            this.setAiStatus({ state: "degraded", providerHealth: "degraded", fallbackMode: "mock-local", detail: `Primary inference failed; mock fallback active: ${reason}` });
+            this.emitMeta({
+              warnings: [reason, "Fallback engaged: mock-local"],
+              dropped: false,
+              blocked: false,
+              cloudRecovery: "degraded",
+              source: "fallback-mock",
+              provider: config.inferenceMode,
+              timeoutMs: config.provider.requestTimeoutMs,
+              retries: config.provider.maxRetries
+            });
+          } catch (fallbackError) {
+            const fallbackReason = (fallbackError as Error).message;
+            this.setAiStatus({ state: "error", providerHealth: "degraded", fallbackMode: null, detail: `Fallback failed: ${fallbackReason}` });
+            if (config.safety.dropOnParseFailure) {
+              this.emitMeta({ warning: `${reason} | fallback failed: ${fallbackReason}`, dropped: true, blocked: false, cloudRecovery: "degraded" });
+            }
+          }
         }
-      });
+        const inferenceLatencyMs = Date.now() - inferenceStarted;
+
+        const safety = applySafetyPolicy(messages, config);
+        const safeMessages = safety.safeMessages;
+
+        safeMessages.forEach((msg) => {
+          if (config.ttsEnabled && config.ttsMode !== "off" && msg.ttsText) {
+            this.audioState.startTts();
+            sharedSttEngine.pause();
+            setTimeout(() => {
+              this.audioState.stopTts();
+              sharedSttEngine.resume();
+            }, 1400);
+            if (this.ttsWatchdogTimer) clearTimeout(this.ttsWatchdogTimer);
+            this.ttsWatchdogTimer = setTimeout(() => {
+              const forced = this.audioState.forceResetIfStale(2800);
+              if (forced) {
+                sharedSttEngine.resume();
+                this.emitMeta({ warnings: ["TTS watchdog forced stale-state reset."], blocked: false });
+              }
+            }, 3200);
+          }
+        });
+
+        this.emitMessages(safeMessages);
+        const latencyMs = Date.now() - startedAt;
+        this.obs.log("pipeline_tick", {
+          inferenceMode: config.inferenceMode,
+          requestedMessageCount: payload.requestedMessageCount,
+          emittedCount: safeMessages.length,
+          latencyMs,
+          captureLatencyMs,
+          inferenceLatencyMs,
+          targetDelayMs: timing.actualDelayMs,
+          jankMs: Math.max(0, latencyMs - timing.actualDelayMs)
+        });
+
+        this.emitMeta({
+          context,
+          timing,
+          audioState: this.getAudioState(),
+          inferenceMode: config.inferenceMode,
+          providerSource: safeMessages[0]?.source ?? "unknown",
+          requestedMessageCount: payload.requestedMessageCount,
+          latencyMs,
+          captureLatencyMs,
+          inferenceLatencyMs,
+          safety: {
+            dropPolicy: config.safety.dropPolicy,
+            droppedCount: safety.droppedCount,
+            queueSize: safety.queueMessages.length
+          },
+          queueMessages: safety.queueMessages,
+          slo: {
+            targetMs: 3000,
+            withinTarget: latencyMs <= 3000
+          },
+          ai: this.getAiStatus(),
+          providerDiagnostics: {
+            timeoutMs: config.provider.requestTimeoutMs,
+            retries: config.provider.maxRetries,
+            fallbackActive: this.aiStatus.fallbackMode !== null
+          }
+        });
+      }
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      this.obs.log("pipeline_loop_crash", { reason });
+      this.setAiStatus({ state: "degraded", providerHealth: "degraded", detail: `Loop recovered after error: ${reason}` });
+      this.emitMeta({ warning: `Simulation loop error recovered: ${reason}`, blocked: false, recovery: "next_tick" });
+    }
+
+    if (!this.running) {
+      return;
     }
 
     this.timer = setTimeout(() => {

--- a/tests/pipeline.test.ts
+++ b/tests/pipeline.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { defaultConfig } from "../src/config/runtimeConfig.js";
 import { mergeConfig, sanitizeConfig } from "../src/config/runtimeConfig.js";
-import { parseInferenceOutput, repairInferenceOutput } from "../src/pipeline/outputParser.js";
+import { classifyMalformedOutput, parseInferenceOutput, repairInferenceOutput } from "../src/pipeline/outputParser.js";
 
 describe("runtime config", () => {
   it("clamps invalid values and supports nested sections", () => {
@@ -45,5 +45,15 @@ describe("output parser", () => {
 
   it("throws when no valid messages are present", () => {
     expect(() => parseInferenceOutput('{"messages":[{"foo":1}]}')).toThrow(/No valid messages/);
+  });
+
+  it("classifies recoverable fenced JSON noise as syntax-repairable", () => {
+    const malformed = "noise ###json\n{\"messages\":[{\"text\":\"yo\",\"emotes\":[]}]}### trailing";
+    expect(classifyMalformedOutput(malformed)).toBe("json_syntax");
+  });
+
+  it("caps oversized payloads to avoid parser stalls and still throws cleanly", () => {
+    const huge = `${"x".repeat(300_000)}{"messages":[{"text":"ok","emotes":[]}]}`;
+    expect(() => parseInferenceOutput(huge)).toThrow();
   });
 });


### PR DESCRIPTION
### Motivation
- Prevent the simulation loop from silently stalling on unexpected runtime errors by ensuring failures are observable and the system recovers to the next tick. 
- Ensure stop/restart flows fully reset audio and capture resources so lingering TTS/STT state or buffered mic data cannot break subsequent sessions. 
- Make inference parsing robust to oversized or noisy AI output so malformed or huge payloads cannot hang the pipeline. 
- Avoid UI race conditions from rapid Start/Stop clicks and ensure mic verification tears down audio nodes cleanly in the browser.

### Description
- Wrapped `SimulationOrchestrator.loop()` in a top-level `try/catch` that logs (`observability`) and emits recovery `meta` so loop crashes no longer silently halt scheduling of the next tick. 
- Strengthened stop cleanup by calling `this.audioState.stopTts()`, `sharedSttEngine.resume()`, and `sharedDeviceCapturePipeline.reset()` inside `SimulationOrchestrator.stop()` to clear TTS/STT and buffered capture state. 
- Hardened inference parsing by adding `MAX_INFERENCE_OUTPUT_CHARS` and a `sanitizeRawOutput()` step, capping raw input length, and fixing classification logic in `classifyMalformedOutput()` and `parsePayload()` so recoverable fenced/noisy JSON is routed to repair/regenerate paths. 
- Improved browser-side mic verification teardown by tracking and disconnecting `ScriptProcessor`/`Analyser`/`MediaStreamSource` nodes and clearing `onaudioprocess` handlers in `stopMicVerificationCheck()` in `src/public/app.js`. 
- Added UI gating to prevent rapid start/stop races via `simulationActionInFlight` and `setSimulationActionPending()` to disable start/stop while an action is in flight. 
- Added tests in `tests/pipeline.test.ts` to assert the malformed fenced JSON classification and to verify oversized payloads are capped and throw cleanly.

### Testing
- Ran `npm test` and all existing tests passed: `15 files, 60 tests` ✅. 
- Ran `npm run build` (TypeScript compile) and the project built successfully with `tsc` ✅.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6c7fb762c8326a0fe23728f056b44)