### PR TITLE
Add gpt-4o-mini-transcribe as a selectable STT provider

### DIFF
--- a/src/capture/sttEngine.ts
+++ b/src/capture/sttEngine.ts
@@ -2,7 +2,7 @@ import { Readable } from "node:stream";
 import { SecretStore } from "../security/secretStore.js";
 import { sharedDeviceCapturePipeline } from "./deviceCapturePipeline.js";
 
-export type SttProviderKind = "mock" | "local-whisper" | "whispercpp" | "deepgram" | "openai-whisper";
+export type SttProviderKind = "mock" | "local-whisper" | "whispercpp" | "deepgram" | "openai-whisper" | "gpt-4o-mini-transcribe";
 
 interface SttBackend {
   transcribe(frame: Buffer): Promise<string>;
@@ -181,6 +181,11 @@ export class DeviceSttEngine implements SttEngine {
       case "openai-whisper":
         return new OpenAiWhisperBackend(
           this.resolveProviderEndpoint(provider, endpoint, process.env.STREAMSIM_OPENAI_STT_ENDPOINT ?? DEFAULT_OPENAI_STT_ENDPOINT),
+          process.env.STREAMSIM_OPENAI_STT_MODEL ?? "whisper-1"
+        );
+      case "gpt-4o-mini-transcribe":
+        return new OpenAiWhisperBackend(
+          this.resolveProviderEndpoint(provider, endpoint, process.env.STREAMSIM_OPENAI_STT_ENDPOINT ?? DEFAULT_OPENAI_STT_ENDPOINT),
           process.env.STREAMSIM_OPENAI_STT_MODEL ?? "gpt-4o-mini-transcribe"
         );
       default:
@@ -188,11 +193,11 @@ export class DeviceSttEngine implements SttEngine {
     }
   }
 
-  private resolveProviderEndpoint(provider: "deepgram" | "openai-whisper", requestedEndpoint: string | undefined, fallback: string): string {
+  private resolveProviderEndpoint(provider: "deepgram" | "openai-whisper" | "gpt-4o-mini-transcribe", requestedEndpoint: string | undefined, fallback: string): string {
     if (!requestedEndpoint) return fallback;
     const normalized = requestedEndpoint.trim();
     if (!normalized) return fallback;
-    if (provider === "openai-whisper" && normalized === DEFAULT_LOCAL_STT_ENDPOINT) {
+    if ((provider === "openai-whisper" || provider === "gpt-4o-mini-transcribe") && normalized === DEFAULT_LOCAL_STT_ENDPOINT) {
       return fallback;
     }
     return normalized;

--- a/src/config/configMigrations.ts
+++ b/src/config/configMigrations.ts
@@ -21,7 +21,8 @@ function migrateV1toV2(input: Record<string, unknown>): Record<string, unknown> 
         capture.sttProvider === "local-whisper" ||
         capture.sttProvider === "whispercpp" ||
         capture.sttProvider === "deepgram" ||
-        capture.sttProvider === "openai-whisper"
+        capture.sttProvider === "openai-whisper" ||
+        capture.sttProvider === "gpt-4o-mini-transcribe"
           ? capture.sttProvider
           : defaultConfig.capture.sttProvider
     }

--- a/src/config/runtimeConfig.ts
+++ b/src/config/runtimeConfig.ts
@@ -97,6 +97,7 @@ export function sanitizeConfig(input: unknown): SimulationConfig {
         capture.sttProvider === "whispercpp" ||
         capture.sttProvider === "deepgram" ||
         capture.sttProvider === "openai-whisper" ||
+        capture.sttProvider === "gpt-4o-mini-transcribe" ||
         capture.sttProvider === "mock"
           ? capture.sttProvider
           : defaultConfig.capture.sttProvider,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -8,7 +8,7 @@ export interface CaptureConfig {
   visionIntervalSec: number;
   useRealCapture: boolean;
   sttEndpoint: string;
-  sttProvider: "mock" | "local-whisper" | "whispercpp" | "deepgram" | "openai-whisper";
+  sttProvider: "mock" | "local-whisper" | "whispercpp" | "deepgram" | "openai-whisper" | "gpt-4o-mini-transcribe";
   visionEndpoint: string;
 }
 

--- a/src/public/app.js
+++ b/src/public/app.js
@@ -48,6 +48,7 @@ const STT_DEFAULT_ENDPOINTS = {
   whispercpp: "http://127.0.0.1:7778/stt",
   deepgram: "https://api.deepgram.com/v1/listen?model=nova-2&punctuate=true",
   "openai-whisper": "https://api.openai.com/v1/audio/transcriptions",
+  "gpt-4o-mini-transcribe": "https://api.openai.com/v1/audio/transcriptions",
   mock: "http://127.0.0.1:7778/stt"
 };
 
@@ -609,9 +610,9 @@ function summarizeSttHealth(payload) {
   } else if (provider === "deepgram" && !sttRuntime.deepgramKeyPresent) {
     ready = false;
     detail = "Deepgram selected but STREAMSIM_DEEPGRAM_API_KEY is missing";
-  } else if (provider === "openai-whisper" && !sttRuntime.cloudKeyPresent) {
+  } else if ((provider === "openai-whisper" || provider === "gpt-4o-mini-transcribe") && !sttRuntime.cloudKeyPresent) {
     ready = false;
-    detail = "OpenAI Whisper selected but no cloud API key is stored";
+    detail = "Cloud OpenAI STT selected but no cloud API key is stored";
   } else if ((provider === "whispercpp" || provider === "local-whisper") && !endpoint.startsWith("http")) {
     ready = false;
     detail = "Whisper endpoint must be a valid URL";
@@ -828,7 +829,9 @@ startBtn.addEventListener("click", async () => {
     onRun: async () => {
       const mode = controls.inferenceMode.value;
       const cloudMode = mode === "openai" || mode === "groq" || mode === "mock-cloud";
-      const cloudStt = controls.useRealCapture.checked && controls.sttProvider.value === "openai-whisper";
+      const cloudStt =
+        controls.useRealCapture.checked &&
+        (controls.sttProvider.value === "openai-whisper" || controls.sttProvider.value === "gpt-4o-mini-transcribe");
       const hasCloudKey = Boolean(latestStatusPayload?.secrets?.hasCloudKey);
       if (cloudMode && !hasCloudKey) {
         throw new Error("Cloud inference selected but no API key is stored. Save a Cloud API key before starting.");
@@ -837,7 +840,7 @@ startBtn.addEventListener("click", async () => {
         throw new Error("Cloud TTS selected but no API key is stored. Save a Cloud API key or switch TTS path to local.");
       }
       if (cloudStt && !hasCloudKey) {
-        throw new Error("OpenAI Whisper STT selected but no API key is stored. Save a Cloud API key or switch STT provider.");
+        throw new Error("Cloud OpenAI STT selected but no API key is stored. Save a Cloud API key or switch STT provider.");
       }
       return post("/api/start");
     }

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -91,6 +91,7 @@
                 <option value="whispercpp">Whisper.cpp (custom endpoint)</option>
                 <option value="deepgram">Deepgram</option>
                 <option value="openai-whisper">OpenAI Whisper (cloud)</option>
+                <option value="gpt-4o-mini-transcribe">OpenAI GPT-4o mini transcribe (cloud)</option>
               </select>
             </label>
             <label>STT endpoint <input id="sttEndpoint" type="text" value="http://127.0.0.1:7778/stt" /></label>

--- a/src/server.ts
+++ b/src/server.ts
@@ -126,7 +126,9 @@ app.post("/api/start", (_req, res) => {
 
   const cloudInference = config.inferenceMode === "openai" || config.inferenceMode === "groq" || config.inferenceMode === "mock-cloud";
   const cloudTts = config.ttsEnabled && config.ttsMode === "cloud";
-  const cloudStt = config.capture.useRealCapture && config.capture.sttProvider === "openai-whisper";
+  const cloudStt =
+    config.capture.useRealCapture &&
+    (config.capture.sttProvider === "openai-whisper" || config.capture.sttProvider === "gpt-4o-mini-transcribe");
   const hasCloudKey = secretStore.diagnostics().hasCloudKey;
 
   if ((cloudInference || cloudTts || cloudStt) && !hasCloudKey) {
@@ -258,7 +260,8 @@ app.get("/api/status", (_req, res) => {
       cloudKeyPresent: secretStore.diagnostics().hasCloudKey,
       endpoint: config.capture.sttEndpoint,
       localConfigured: config.capture.sttProvider === "local-whisper",
-      openAiWhisperConfigured: config.capture.sttProvider === "openai-whisper"
+      openAiWhisperConfigured: config.capture.sttProvider === "openai-whisper",
+      gpt4oMiniTranscribeConfigured: config.capture.sttProvider === "gpt-4o-mini-transcribe"
     },
     onboardingComplete,
     bootDiagnostics: {

--- a/src/services/readinessChecks.ts
+++ b/src/services/readinessChecks.ts
@@ -39,8 +39,12 @@ function checkDevice(config: SimulationConfig, hasCloudKey: boolean): ReadinessC
     errors.push("Deepgram STT selected but STREAMSIM_DEEPGRAM_API_KEY is missing.");
   }
 
-  if (config.capture.useRealCapture && config.capture.sttProvider === "openai-whisper" && !hasCloudKey) {
-    errors.push("OpenAI Whisper STT selected but no cloud API key is stored.");
+  if (
+    config.capture.useRealCapture &&
+    (config.capture.sttProvider === "openai-whisper" || config.capture.sttProvider === "gpt-4o-mini-transcribe") &&
+    !hasCloudKey
+  ) {
+    errors.push("Cloud OpenAI STT selected but no cloud API key is stored.");
   }
 
   if (config.capture.useRealCapture && (config.capture.sttProvider === "whispercpp" || config.capture.sttProvider === "local-whisper") && !config.capture.sttEndpoint.startsWith("http")) {


### PR DESCRIPTION
### Motivation

- Provide GPT-4o mini transcribe as an alternative OpenAI cloud STT option alongside the existing Whisper option so users can select either model for speech-to-text.

### Description

- Add `gpt-4o-mini-transcribe` to the `SttProviderKind` type and `CaptureConfig.sttProvider` so it is supported across typed config, sanitization, and migrations (`src/capture/sttEngine.ts`, `src/core/types.ts`, `src/config/runtimeConfig.ts`, `src/config/configMigrations.ts`).
- Route the new provider to the existing OpenAI transcription backend in `DeviceSttEngine#createBackend`, defaulting `openai-whisper` to model `whisper-1` and `gpt-4o-mini-transcribe` to model `gpt-4o-mini-transcribe`, and extend endpoint-resolution logic to treat both cloud OpenAI providers consistently (`src/capture/sttEngine.ts`).
- Expose the option in the Control Center UI and default endpoint map, and update client-side health/start checks to treat either OpenAI STT choice as cloud-gated (`src/public/index.html`, `src/public/app.js`).
- Update readiness/startup/server status payloads and device readiness checks to consider `gpt-4o-mini-transcribe` as a cloud STT option requiring a stored cloud API key (`src/services/readinessChecks.ts`, `src/server.ts`).

### Testing

- Ran a TypeScript build with `npm run build` and the build completed successfully.
- Executed the test suite with `npm test` (Vitest) and all tests passed (`60 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6cd58689c832688f188f97670aa1c)