### PR TITLE
Omit temperature for GPT-5 cloud models

### DIFF
--- a/src/llm/realInferenceProvider.ts
+++ b/src/llm/realInferenceProvider.ts
@@ -112,6 +112,11 @@ function systemPromptForPayload(payload: PromptPayload): string {
   ].join(" ");
 }
 
+function cloudModelSupportsTemperature(model: string): boolean {
+  const normalized = model.trim().toLowerCase();
+  return !/^gpt-5(?:$|[-:])/.test(normalized);
+}
+
 export class HybridInferenceProvider implements InferenceProvider {
   private readonly mockProvider = new MockInferenceProvider();
   private readonly secretStore = new SecretStore();
@@ -218,6 +223,21 @@ export class HybridInferenceProvider implements InferenceProvider {
       throw new Error("Missing cloud API key in keychain for cloud provider.");
     }
 
+    const body: {
+      model: string;
+      temperature?: number;
+      messages: Array<{ role: "system" | "user"; content: string }>;
+    } = {
+      model: config.provider.cloudModel,
+      messages: [
+        { role: "system", content: systemPromptForPayload(payload) },
+        { role: "user", content: JSON.stringify(payload) }
+      ]
+    };
+    if (cloudModelSupportsTemperature(config.provider.cloudModel)) {
+      body.temperature = 0.8;
+    }
+
     let response: Response;
     try {
       response = await fetch(config.provider.cloudEndpoint, {
@@ -227,14 +247,7 @@ export class HybridInferenceProvider implements InferenceProvider {
           ...this.cloudHeaders(apiKey)
         },
         signal: AbortSignal.timeout(config.provider.requestTimeoutMs),
-        body: JSON.stringify({
-          model: config.provider.cloudModel,
-          temperature: 0.8,
-          messages: [
-            { role: "system", content: systemPromptForPayload(payload) },
-            { role: "user", content: JSON.stringify(payload) }
-          ]
-        })
+        body: JSON.stringify(body)
       });
     } catch (error) {
       const message = (error as Error).message || "request failed";

--- a/tests/integrationRouting.test.ts
+++ b/tests/integrationRouting.test.ts
@@ -177,6 +177,7 @@ describe("hybrid routing and failover", () => {
       req.on("end", () => {
         const parsed = JSON.parse(body);
         expect(parsed.messages[1].role).toBe("user");
+        expect(parsed.temperature).toBe(0.8);
         res.writeHead(200, { "Content-Type": "application/json" });
         res.end(JSON.stringify({ choices: [{ message: { content: '{"messages":[]}' } }] }));
       });
@@ -233,6 +234,41 @@ describe("hybrid routing and failover", () => {
     };
 
     await expect(provider.generate(payload, config)).resolves.toContain('"username":"newapi"');
+    await server.close();
+  });
+
+  it("omits temperature for GPT-5 family cloud models", async () => {
+    process.env.STREAMSIM_CLOUD_API_KEY = "abc123";
+    const server = await withTestServer((req, res) => {
+      if (req.method !== "POST") {
+        res.writeHead(404);
+        res.end();
+        return;
+      }
+
+      let body = "";
+      req.on("data", (chunk: Buffer) => (body += chunk.toString("utf8")));
+      req.on("end", () => {
+        const parsed = JSON.parse(body);
+        expect(parsed.model).toBe("gpt-5-mini");
+        expect(parsed.temperature).toBeUndefined();
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ choices: [{ message: { content: '{"messages":[]}' } }] }));
+      });
+    });
+
+    const provider = new HybridInferenceProvider("openai");
+    const config = { ...defaultConfig, provider: { ...defaultConfig.provider, cloudEndpoint: server.url, cloudModel: "gpt-5-mini" } };
+    const payload = {
+      persona: "supportive" as const,
+      bias: "agree" as const,
+      emoteOnly: false,
+      viewerCount: 10,
+      requestedMessageCount: 1,
+      context: { transcript: "switch now", tone: { volumeRms: 0.5, paceWpm: 140 }, visionTags: ["monitor"], timestamp: new Date().toISOString() }
+    };
+
+    await expect(provider.generate(payload, config)).resolves.toContain("messages");
     await server.close();
   });
 });


### PR DESCRIPTION
### Motivation
- Prevent OpenAI 400 errors and unintended fallback to mock providers when using GPT-5 family cloud models that do not accept the `temperature` parameter.
- Preserve existing behavior (include `temperature: 0.8`) for non-GPT-5 cloud/chat models that still accept temperature.

### Description
- Add `cloudModelSupportsTemperature(model)` helper that treats model IDs starting with the GPT-5 family (`gpt-5`, `gpt-5-mini`, `gpt-5-nano`, etc.) as not supporting `temperature`.
- Construct the cloud request body as an object and only set `temperature` when `cloudModelSupportsTemperature` returns true, then `JSON.stringify` that body for the fetch call in `generateCloud`.
- Update integration tests to assert that non-GPT-5 requests include `temperature` and GPT-5-family requests omit it.
- Modified files: `src/llm/realInferenceProvider.ts` and `tests/integrationRouting.test.ts`.

### Testing
- Ran `npm test -- tests/integrationRouting.test.ts` and all tests passed (11/11).
- The updated integration test verifies both inclusion and omission of `temperature` as expected and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6d2f460488326953b144eb07dbc52)