### PR TITLE
Increase default cloud timeout and add adaptive retry capping

### DIFF
--- a/src/config/runtimeConfig.ts
+++ b/src/config/runtimeConfig.ts
@@ -33,8 +33,8 @@ export const defaultConfig: SimulationConfig = {
     localModel: "llama3.1:8b-instruct-q4_K_M",
     cloudEndpoint: "https://api.openai.com/v1/chat/completions",
     cloudModel: "gpt-5-nano",
-    requestTimeoutMs: 7000,
-    maxRetries: 2
+    requestTimeoutMs: 15000,
+    maxRetries: 1
   },
   security: {
     sidecarLocalhostOnly: true,

--- a/src/llm/realInferenceProvider.ts
+++ b/src/llm/realInferenceProvider.ts
@@ -25,6 +25,12 @@ async function withRetry<T>(attempts: number, fn: () => Promise<T>, onRetryProgr
   throw lastError;
 }
 
+function effectiveRetryCount(maxRetries: number, requestTimeoutMs: number): number {
+  if (requestTimeoutMs >= 30000) return 0;
+  if (requestTimeoutMs >= 15000) return Math.min(maxRetries, 1);
+  return maxRetries;
+}
+
 async function parseProviderError(response: Response): Promise<string> {
   const retryAfter = response.headers.get("retry-after");
   const remaining = response.headers.get("x-ratelimit-remaining-requests") ?? response.headers.get("x-ratelimit-remaining");
@@ -164,9 +170,11 @@ export class HybridInferenceProvider implements InferenceProvider {
       return this.mockProvider.generate(payload, { ...config, inferenceMode: this.mode }, onRetryProgress);
     }
 
+    const retries = effectiveRetryCount(config.provider.maxRetries, config.provider.requestTimeoutMs);
+
     try {
       return await withRetry(
-        config.provider.maxRetries,
+        retries,
         async () => {
           if (this.mode === "ollama" || this.mode === "lmstudio") {
             return this.generateLocal(payload, config);
@@ -177,8 +185,8 @@ export class HybridInferenceProvider implements InferenceProvider {
       );
     } catch (primaryError) {
       if (this.mode === "ollama" || this.mode === "lmstudio") {
-        onRetryProgress?.(config.provider.maxRetries + 1, `Local failure: ${(primaryError as Error).message}; falling back to cloud.`);
-        return withRetry(config.provider.maxRetries, async () => this.generateCloud(payload, config), onRetryProgress);
+        onRetryProgress?.(retries + 1, `Local failure: ${(primaryError as Error).message}; falling back to cloud.`);
+        return withRetry(retries, async () => this.generateCloud(payload, config), onRetryProgress);
       }
       throw primaryError;
     }

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -71,8 +71,8 @@
             <label>Local model <input id="localModel" type="text" value="llama3.1:8b-instruct-q4_K_M" /></label>
             <label>Cloud endpoint <input id="cloudEndpoint" type="text" value="https://api.openai.com/v1/chat/completions" /></label>
             <label>Cloud model <input id="cloudModel" type="text" value="gpt-5-nano" /></label>
-            <label>Request timeout ms <input id="requestTimeoutMs" type="number" min="1000" max="30000" value="7000" /></label>
-            <label>Max retries <input id="maxRetries" type="number" min="0" max="5" value="2" /></label>
+            <label>Request timeout ms <input id="requestTimeoutMs" type="number" min="1000" max="30000" value="15000" /></label>
+            <label>Max retries <input id="maxRetries" type="number" min="0" max="5" value="1" /></label>
             <label><input id="ttsEnabled" type="checkbox" checked /> TTS Enabled</label>
             <label>TTS Path
               <select id="ttsMode">

--- a/tests/integrationRouting.test.ts
+++ b/tests/integrationRouting.test.ts
@@ -163,6 +163,34 @@ describe("hybrid routing and failover", () => {
     await expect(provider.generate(payload, config)).rejects.toThrow(/timeout\/network failure/i);
   });
 
+  it("caps retries for longer timeout windows to avoid prolonged fallback delays", async () => {
+    process.env.STREAMSIM_CLOUD_API_KEY = "abc123";
+    let attemptCount = 0;
+    const server = await withTestServer((_req, res) => {
+      attemptCount += 1;
+      res.writeHead(503, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: { message: "temporary overload" } }));
+    });
+
+    const provider = new HybridInferenceProvider("openai");
+    const config = {
+      ...defaultConfig,
+      provider: { ...defaultConfig.provider, cloudEndpoint: server.url, cloudModel: "x", requestTimeoutMs: 15000, maxRetries: 4 }
+    };
+    const payload = {
+      persona: "supportive" as const,
+      bias: "agree" as const,
+      emoteOnly: false,
+      viewerCount: 10,
+      requestedMessageCount: 1,
+      context: { transcript: "switch now", tone: { volumeRms: 0.5, paceWpm: 140 }, visionTags: ["monitor"], timestamp: new Date().toISOString() }
+    };
+
+    await expect(provider.generate(payload, config)).rejects.toThrow(/503/);
+    expect(attemptCount).toBe(2);
+    await server.close();
+  });
+
   it("routes openai/groq cloud requests with runtime mode switching", async () => {
     process.env.STREAMSIM_CLOUD_API_KEY = "abc123";
     const server = await withTestServer(async (req, res) => {


### PR DESCRIPTION
### Motivation
- Cloud LLM requests were frequently timing out at a short default (7s) and multiple retries caused long perceived stalls before fallback, degrading the AI health UX.
- Users need the ability to tune the timeout from the Control Center while avoiding long multi-retry delays when each attempt is already long.

### Description
- Bumped provider defaults in `src/config/runtimeConfig.ts` from `requestTimeoutMs: 7000`/`maxRetries: 2` to `requestTimeoutMs: 15000`/`maxRetries: 1` to give cloud inference more headroom.
- Updated Provider control defaults in `src/public/index.html` to mirror the new timeout (`15000`) and retry (`1`) baseline so the setting remains user-adjustable in the Control Center.
- Added an `effectiveRetryCount` helper in `src/llm/realInferenceProvider.ts` and wired it into the request flow so retries are adaptively capped based on `requestTimeoutMs` (>=15s caps to 1 retry, >=30s disables retries).
- Added an integration test in `tests/integrationRouting.test.ts` that asserts retry capping behavior for longer timeout windows to prevent prolonged fallback delays.

### Testing
- Ran `npm test -- tests/integrationRouting.test.ts`, which passed (12 tests in the file all green).
- Ran `npm run build`, which completed successfully and produced no TypeScript errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6e2b42c048326bdea28bfee424d0a)