### PR TITLE
Add cloud-model fallbacks, extend timeouts, and tighten system prompt for reactive messages

### DIFF
--- a/src/config/runtimeConfig.ts
+++ b/src/config/runtimeConfig.ts
@@ -32,8 +32,8 @@ export const defaultConfig: SimulationConfig = {
     localEndpoint: "http://127.0.0.1:11434",
     localModel: "llama3.1:8b-instruct-q4_K_M",
     cloudEndpoint: "https://api.openai.com/v1/chat/completions",
-    cloudModel: "gpt-5-nano",
-    requestTimeoutMs: 15000,
+    cloudModel: "gpt-5.4-nano-2026-03-17",
+    requestTimeoutMs: 30000,
     maxRetries: 1
   },
   security: {
@@ -117,7 +117,7 @@ export function sanitizeConfig(input: unknown): SimulationConfig {
       localModel: asString(provider.localModel, defaultConfig.provider.localModel),
       cloudEndpoint: asString(provider.cloudEndpoint, defaultConfig.provider.cloudEndpoint),
       cloudModel: asString(provider.cloudModel, defaultConfig.provider.cloudModel),
-      requestTimeoutMs: Math.max(1000, Math.min(30000, Math.floor(asNumber(provider.requestTimeoutMs, defaultConfig.provider.requestTimeoutMs)))),
+      requestTimeoutMs: Math.max(1000, Math.min(120000, Math.floor(asNumber(provider.requestTimeoutMs, defaultConfig.provider.requestTimeoutMs)))),
       maxRetries: Math.max(0, Math.min(5, Math.floor(asNumber(provider.maxRetries, defaultConfig.provider.maxRetries))))
     },
     security: {

--- a/src/llm/realInferenceProvider.ts
+++ b/src/llm/realInferenceProvider.ts
@@ -108,19 +108,40 @@ function systemPromptForPayload(payload: PromptPayload): string {
   const transcriptDirective = transcript
     ? `Highest priority: react directly to the streamer's latest words from context.transcript ("${transcript.slice(0, 220)}").`
     : "No transcript text is available right now; infer likely chat reactions from tone + vision tags without inventing quoted speech.";
+  const questionDirective = transcript && /\?/.test(transcript)
+    ? "The transcript includes a question; at least one message must directly answer or acknowledge that question."
+    : "If no question is present in the transcript, avoid inventing one.";
 
   return [
     'Return strict JSON only: {"messages":[{"text":"string","emotes":["string"],"donationCents":number?,"ttsText":"string?"}]}. Never include usernames.',
     "You are simulating a live audience reacting to the streamer in real time (not a generic standalone chat).",
     transcriptDirective,
+    questionDirective,
     "Treat context.transcript as more important than persona flavor text when they conflict.",
-    "Reference concrete details from context (transcript/tone/vision) in at least half of the messages."
+    "At least 70% of messages must reference specific transcript/tone/vision details.",
+    "Do not output generic filler like 'positive vibes', 'keep it up', or cheerleading with no context anchors.",
+    "Supportive persona means kind tone, not generic praise; keep every message situational and reactive."
   ].join(" ");
 }
 
 function cloudModelSupportsTemperature(model: string): boolean {
   const normalized = model.trim().toLowerCase();
-  return !/^gpt-5(?:$|[-:])/.test(normalized);
+  return !/^gpt-5(?:$|[.:-])/.test(normalized);
+}
+
+const CLOUD_MODEL_FALLBACKS: Record<string, string[]> = {
+  "gpt-5.4-nano-2026-03-17": ["gpt-5-mini", "gpt-4o-mini"],
+  "gpt-5-nano": ["gpt-5-mini", "gpt-4o-mini"]
+};
+
+function cloudModelCandidates(model: string): string[] {
+  const normalized = model.trim().toLowerCase();
+  const candidates = [model.trim(), ...(CLOUD_MODEL_FALLBACKS[normalized] ?? [])];
+  return candidates.filter((candidate, idx) => candidate.length > 0 && candidates.indexOf(candidate) === idx);
+}
+
+function isRetryableCloudFailure(message: string): boolean {
+  return /timeout|network failure|\(408\)|\(429\)|\(5\d\d\)/i.test(message);
 }
 
 export class HybridInferenceProvider implements InferenceProvider {
@@ -231,44 +252,58 @@ export class HybridInferenceProvider implements InferenceProvider {
       throw new Error("Missing cloud API key in keychain for cloud provider.");
     }
 
-    const body: {
-      model: string;
-      temperature?: number;
-      messages: Array<{ role: "system" | "user"; content: string }>;
-    } = {
-      model: config.provider.cloudModel,
-      messages: [
-        { role: "system", content: systemPromptForPayload(payload) },
-        { role: "user", content: JSON.stringify(payload) }
-      ]
-    };
-    if (cloudModelSupportsTemperature(config.provider.cloudModel)) {
-      body.temperature = 0.8;
+    const systemPrompt = systemPromptForPayload(payload);
+    const messages = [
+      { role: "system" as const, content: systemPrompt },
+      { role: "user" as const, content: JSON.stringify(payload) }
+    ];
+
+    let lastError: Error | null = null;
+    for (const model of cloudModelCandidates(config.provider.cloudModel)) {
+      const body: {
+        model: string;
+        temperature?: number;
+        messages: Array<{ role: "system" | "user"; content: string }>;
+      } = {
+        model,
+        messages
+      };
+      if (cloudModelSupportsTemperature(model)) {
+        body.temperature = 0.8;
+      }
+
+      let response: Response;
+      try {
+        response = await fetch(config.provider.cloudEndpoint, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            ...this.cloudHeaders(apiKey)
+          },
+          signal: AbortSignal.timeout(config.provider.requestTimeoutMs),
+          body: JSON.stringify(body)
+        });
+      } catch (error) {
+        const message = (error as Error).message || "request failed";
+        lastError = new Error(`Cloud provider timeout/network failure for model ${model}: ${message}`);
+        if (model === config.provider.cloudModel && isRetryableCloudFailure(lastError.message)) continue;
+        throw lastError;
+      }
+
+      if (!response.ok) {
+        const detail = await parseProviderError(response);
+        lastError = new Error(`Cloud provider failed (${response.status}) for model ${model}${detail ? `: ${detail}` : ""}`);
+        if (model === config.provider.cloudModel && isRetryableCloudFailure(lastError.message)) {
+          continue;
+        }
+        throw lastError;
+      }
+
+      const data = (await response.json()) as ProviderResponseShape;
+      return extractProviderText(data);
     }
 
-    let response: Response;
-    try {
-      response = await fetch(config.provider.cloudEndpoint, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          ...this.cloudHeaders(apiKey)
-        },
-        signal: AbortSignal.timeout(config.provider.requestTimeoutMs),
-        body: JSON.stringify(body)
-      });
-    } catch (error) {
-      const message = (error as Error).message || "request failed";
-      throw new Error(`Cloud provider timeout/network failure: ${message}`);
-    }
-
-    if (!response.ok) {
-      const detail = await parseProviderError(response);
-      throw new Error(`Cloud provider failed (${response.status})${detail ? `: ${detail}` : ""}`);
-    }
-
-    const data = (await response.json()) as ProviderResponseShape;
-    return extractProviderText(data);
+    throw lastError ?? new Error("Cloud provider failed before receiving a response.");
   }
 
   private healthEndpointForCloud(config: SimulationConfig): string {

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -70,8 +70,8 @@
             <label>Local endpoint <input id="localEndpoint" type="text" value="http://127.0.0.1:11434" /></label>
             <label>Local model <input id="localModel" type="text" value="llama3.1:8b-instruct-q4_K_M" /></label>
             <label>Cloud endpoint <input id="cloudEndpoint" type="text" value="https://api.openai.com/v1/chat/completions" /></label>
-            <label>Cloud model <input id="cloudModel" type="text" value="gpt-5-nano" /></label>
-            <label>Request timeout ms <input id="requestTimeoutMs" type="number" min="1000" max="30000" value="15000" /></label>
+            <label>Cloud model <input id="cloudModel" type="text" value="gpt-5.4-nano-2026-03-17" /></label>
+            <label>Request timeout ms <input id="requestTimeoutMs" type="number" min="1000" max="120000" value="30000" /></label>
             <label>Max retries <input id="maxRetries" type="number" min="0" max="5" value="1" /></label>
             <label><input id="ttsEnabled" type="checkbox" checked /> TTS Enabled</label>
             <label>TTS Path

--- a/tests/integrationRouting.test.ts
+++ b/tests/integrationRouting.test.ts
@@ -299,6 +299,87 @@ describe("hybrid routing and failover", () => {
     await expect(provider.generate(payload, config)).resolves.toContain("messages");
     await server.close();
   });
+
+  it("falls back from gpt-5.4-nano-2026-03-17 to gpt-5-mini on timeout/network failure", async () => {
+    process.env.STREAMSIM_CLOUD_API_KEY = "abc123";
+    const modelsSeen: string[] = [];
+    const server = await withTestServer((req, res) => {
+      if (req.method !== "POST") {
+        res.writeHead(404);
+        res.end();
+        return;
+      }
+
+      let body = "";
+      req.on("data", (chunk: Buffer) => (body += chunk.toString("utf8")));
+      req.on("end", () => {
+        const parsed = JSON.parse(body);
+        modelsSeen.push(parsed.model);
+        if (parsed.model === "gpt-5.4-nano-2026-03-17") {
+          res.writeHead(503, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: { message: "upstream timeout" } }));
+          return;
+        }
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ choices: [{ message: { content: '{"messages":[]}' } }] }));
+      });
+    });
+
+    const provider = new HybridInferenceProvider("openai");
+    const config = { ...defaultConfig, provider: { ...defaultConfig.provider, cloudEndpoint: server.url, cloudModel: "gpt-5.4-nano-2026-03-17", maxRetries: 0 } };
+    const payload = {
+      persona: "supportive" as const,
+      bias: "agree" as const,
+      emoteOnly: false,
+      viewerCount: 10,
+      requestedMessageCount: 1,
+      context: { transcript: "can you hear me?", tone: { volumeRms: 0.5, paceWpm: 140 }, visionTags: ["monitor"], timestamp: new Date().toISOString() }
+    };
+
+    await expect(provider.generate(payload, config)).resolves.toContain("messages");
+    expect(modelsSeen).toEqual(["gpt-5.4-nano-2026-03-17", "gpt-5-mini"]);
+    await server.close();
+  });
+
+  it("includes context.transcript and anti-generic reactive instructions in system prompt", async () => {
+    process.env.STREAMSIM_CLOUD_API_KEY = "abc123";
+    const server = await withTestServer((req, res) => {
+      if (req.method !== "POST") {
+        res.writeHead(404);
+        res.end();
+        return;
+      }
+
+      let body = "";
+      req.on("data", (chunk: Buffer) => (body += chunk.toString("utf8")));
+      req.on("end", () => {
+        const parsed = JSON.parse(body);
+        const systemPrompt = parsed.messages[0]?.content as string;
+        const userPayload = JSON.parse(parsed.messages[1]?.content as string);
+
+        expect(systemPrompt).toMatch(/react directly to the streamer's latest words/i);
+        expect(systemPrompt).toMatch(/Do not output generic filler/i);
+        expect(userPayload.context.transcript).toBe("can you hear me?");
+
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ choices: [{ message: { content: '{"messages":[]}' } }] }));
+      });
+    });
+
+    const provider = new HybridInferenceProvider("openai");
+    const config = { ...defaultConfig, provider: { ...defaultConfig.provider, cloudEndpoint: server.url, cloudModel: "gpt-4o-mini", maxRetries: 0 } };
+    const payload = {
+      persona: "supportive" as const,
+      bias: "agree" as const,
+      emoteOnly: false,
+      viewerCount: 10,
+      requestedMessageCount: 1,
+      context: { transcript: "can you hear me?", tone: { volumeRms: 0.5, paceWpm: 140 }, visionTags: ["headset"], timestamp: new Date().toISOString() }
+    };
+
+    await expect(provider.generate(payload, config)).resolves.toContain("messages");
+    await server.close();
+  });
 });
 
 describe("device capture pipeline + security + observability schema", () => {


### PR DESCRIPTION
### Motivation

- Add support for a renamed/new cloud model and provide automatic fallbacks when that model times out or fails. 
- Increase allowable cloud request timeout to better tolerate slower provider responses. 
- Strengthen the system prompt so generated chat messages are explicitly reactive, situational, and answer transcript questions when present.

### Description

- Updated defaults in `src/config/runtimeConfig.ts` and `src/public/index.html` to use `gpt-5.4-nano-2026-03-17` and raise the default `requestTimeoutMs` to `30000`, and increased the sanitization max to `120000`.
- Enhanced `systemPromptForPayload` in `src/llm/realInferenceProvider.ts` to add a question-aware directive, require more transcript/tone/vision grounding, and ban generic filler messaging.
- Implemented cloud-model fallback logic by refining the model-name handling regex, adding `CLOUD_MODEL_FALLBACKS`, `cloudModelCandidates`, and `isRetryableCloudFailure`, and updated `generateCloud` to try the primary model then fall back to candidates on retryable failures.
- Added tests in `tests/integrationRouting.test.ts` to verify fallback behavior from `gpt-5.4-nano-2026-03-17` to `gpt-5-mini` and to assert the system prompt includes the transcript and anti-generic instructions.

### Testing

- Ran the project test suite via `npm test`, which included the updated `tests/integrationRouting.test.ts` integration cases. 
- The new integration tests for model fallback and system-prompt contents executed and passed. 
- Existing routing and capture tests were re-run and continued to pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6ef8305708326abf6a7ce080c3252)