### PR TITLE
Hide raw telemetry from LLM, add small-talk fallback, and normalize capture ingestion

### DIFF
--- a/src/capture/captureProviders.ts
+++ b/src/capture/captureProviders.ts
@@ -4,8 +4,21 @@ import { sharedDeviceCapturePipeline } from "./deviceCapturePipeline.js";
 
 interface JsonCaptureResponse {
   transcript?: string;
+  text?: string;
   tone?: { volumeRms?: number; paceWpm?: number };
   visionTags?: string[];
+  tags?: string[];
+  results?: { channels?: Array<{ alternatives?: Array<{ transcript?: string }> }> };
+}
+
+function normalizeTranscript(payload: JsonCaptureResponse): string {
+  const fromTopLevel = payload.transcript ?? payload.text ?? payload.results?.channels?.[0]?.alternatives?.[0]?.transcript ?? "";
+  return typeof fromTopLevel === "string" ? fromTopLevel.trim() : "";
+}
+
+function normalizeVisionTags(payload: JsonCaptureResponse): string[] {
+  const raw = Array.isArray(payload.visionTags) ? payload.visionTags : Array.isArray(payload.tags) ? payload.tags : [];
+  return raw.filter((tag): tag is string => typeof tag === "string").map((tag) => tag.trim()).filter(Boolean);
 }
 
 export class MockCaptureProvider implements CaptureProvider {
@@ -35,15 +48,17 @@ export class EndpointCaptureProvider implements CaptureProvider {
       const sttData = ((sttRes && sttRes.ok ? await sttRes.json() : {}) ?? {}) as JsonCaptureResponse;
       const visionData = ((visionRes && visionRes.ok ? await visionRes.json() : {}) ?? {}) as JsonCaptureResponse;
 
-      if (sttData.transcript) {
+      const transcript = normalizeTranscript(sttData);
+      if (transcript) {
         sharedDeviceCapturePipeline.ingestMicFrame({
-          transcriptChunk: sttData.transcript,
+          transcriptChunk: transcript,
           rms: sttData.tone?.volumeRms,
           wordsPerMinute: sttData.tone?.paceWpm
         });
       }
-      if (Array.isArray(visionData.visionTags)) {
-        sharedDeviceCapturePipeline.ingestVisionSample({ tags: visionData.visionTags });
+      const visionTags = normalizeVisionTags(visionData);
+      if (visionTags.length) {
+        sharedDeviceCapturePipeline.ingestVisionSample({ tags: visionTags });
       }
 
       return this.fallback.getContext(config);

--- a/src/llm/realInferenceProvider.ts
+++ b/src/llm/realInferenceProvider.ts
@@ -107,7 +107,7 @@ function systemPromptForPayload(payload: PromptPayload): string {
   const transcript = payload.context.transcript.trim();
   const transcriptDirective = transcript
     ? `Highest priority: react directly to the streamer's latest words from context.transcript ("${transcript.slice(0, 220)}").`
-    : "No transcript text is available right now; infer likely chat reactions from tone + vision tags without inventing quoted speech.";
+    : "No transcript text is available right now. Fall back to persona-led small talk and channel chatter topics without claiming missing feeds or missing tags.";
   const questionDirective = transcript && /\?/.test(transcript)
     ? "The transcript includes a question; at least one message must directly answer or acknowledge that question."
     : "If no question is present in the transcript, avoid inventing one.";
@@ -119,9 +119,45 @@ function systemPromptForPayload(payload: PromptPayload): string {
     questionDirective,
     "Treat context.transcript as more important than persona flavor text when they conflict.",
     "At least 70% of messages must reference specific transcript/tone/vision details.",
+    "Never mention RMS, WPM, telemetry, diagnostics, pipelines, or whether tags/transcript are missing.",
+    "Do not break the fourth wall by discussing system input quality or capture internals.",
     "Do not output generic filler like 'positive vibes', 'keep it up', or cheerleading with no context anchors.",
     "Supportive persona means kind tone, not generic praise; keep every message situational and reactive."
   ].join(" ");
+}
+
+function describeEnergy(volumeRms: number): "low" | "steady" | "high" {
+  if (volumeRms < 0.34) return "low";
+  if (volumeRms > 0.62) return "high";
+  return "steady";
+}
+
+function describePace(paceWpm: number): "slow" | "normal" | "fast" {
+  if (paceWpm < 100) return "slow";
+  if (paceWpm > 155) return "fast";
+  return "normal";
+}
+
+function buildModelFacingPayload(payload: PromptPayload): Record<string, unknown> {
+  return {
+    persona: payload.persona,
+    bias: payload.bias,
+    emoteOnly: payload.emoteOnly,
+    viewerCount: payload.viewerCount,
+    requestedMessageCount: payload.requestedMessageCount,
+    context: {
+      transcript: payload.context.transcript,
+      transcriptAvailable: payload.context.transcript.trim().length > 0,
+      tone: {
+        energy: describeEnergy(payload.context.tone.volumeRms),
+        pace: describePace(payload.context.tone.paceWpm)
+      },
+      visionTags: payload.context.visionTags,
+      timestamp: payload.context.timestamp
+    },
+    personaCalibration: payload.personaCalibration,
+    providerConditioning: payload.providerConditioning
+  };
 }
 
 function cloudModelSupportsTemperature(model: string): boolean {
@@ -222,13 +258,13 @@ export class HybridInferenceProvider implements InferenceProvider {
           temperature: 0.8,
           messages: [
             { role: "system", content: systemPromptForPayload(payload) },
-            { role: "user", content: JSON.stringify(payload) }
+            { role: "user", content: JSON.stringify(buildModelFacingPayload(payload)) }
           ]
         }
       : {
           model: config.provider.localModel,
           stream: false,
-          prompt: JSON.stringify(payload)
+          prompt: JSON.stringify(buildModelFacingPayload(payload))
         };
 
     const response = await fetch(endpoint, {
@@ -253,9 +289,10 @@ export class HybridInferenceProvider implements InferenceProvider {
     }
 
     const systemPrompt = systemPromptForPayload(payload);
+    const modelFacingPayload = buildModelFacingPayload(payload);
     const messages = [
       { role: "system" as const, content: systemPrompt },
-      { role: "user" as const, content: JSON.stringify(payload) }
+      { role: "user" as const, content: JSON.stringify(modelFacingPayload) }
     ];
 
     let lastError: Error | null = null;

--- a/tests/integrationRouting.test.ts
+++ b/tests/integrationRouting.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { defaultConfig } from "../src/config/runtimeConfig.js";
 import { HybridInferenceProvider } from "../src/llm/realInferenceProvider.js";
 import { DeviceCapturePipeline } from "../src/capture/deviceCapturePipeline.js";
+import { EndpointCaptureProvider } from "../src/capture/captureProviders.js";
 import { redactSecrets } from "../src/security/diagnostics.js";
 import { isValidObservabilityEvent } from "../src/services/observability.js";
 
@@ -380,6 +381,50 @@ describe("hybrid routing and failover", () => {
     await expect(provider.generate(payload, config)).resolves.toContain("messages");
     await server.close();
   });
+
+  it("uses small-talk fallback instructions and strips raw numeric telemetry from user payload", async () => {
+    process.env.STREAMSIM_CLOUD_API_KEY = "abc123";
+    const server = await withTestServer((req, res) => {
+      if (req.method !== "POST") {
+        res.writeHead(404);
+        res.end();
+        return;
+      }
+
+      let body = "";
+      req.on("data", (chunk: Buffer) => (body += chunk.toString("utf8")));
+      req.on("end", () => {
+        const parsed = JSON.parse(body);
+        const systemPrompt = parsed.messages[0]?.content as string;
+        const userPayload = JSON.parse(parsed.messages[1]?.content as string);
+
+        expect(systemPrompt).toMatch(/small talk/i);
+        expect(systemPrompt).toMatch(/never mention RMS, WPM, telemetry/i);
+        expect(userPayload.context.transcriptAvailable).toBe(false);
+        expect(userPayload.context.tone.energy).toBe("high");
+        expect(userPayload.context.tone.pace).toBe("fast");
+        expect(typeof userPayload.context.tone.volumeRms).toBe("undefined");
+        expect(typeof userPayload.context.tone.paceWpm).toBe("undefined");
+
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ choices: [{ message: { content: '{"messages":[]}' } }] }));
+      });
+    });
+
+    const provider = new HybridInferenceProvider("openai");
+    const config = { ...defaultConfig, provider: { ...defaultConfig.provider, cloudEndpoint: server.url, cloudModel: "gpt-4o-mini", maxRetries: 0 } };
+    const payload = {
+      persona: "supportive" as const,
+      bias: "agree" as const,
+      emoteOnly: false,
+      viewerCount: 10,
+      requestedMessageCount: 1,
+      context: { transcript: "", tone: { volumeRms: 0.8, paceWpm: 180 }, visionTags: [], timestamp: new Date().toISOString() }
+    };
+
+    await expect(provider.generate(payload, config)).resolves.toContain("messages");
+    await server.close();
+  });
 });
 
 describe("device capture pipeline + security + observability schema", () => {
@@ -407,5 +452,34 @@ describe("device capture pipeline + security + observability schema", () => {
   it("validates structured observability schema", () => {
     expect(isValidObservabilityEvent({ event: "pipeline_tick", at: new Date().toISOString(), latencyMs: 200 })).toBe(true);
     expect(isValidObservabilityEvent({ event: 1, at: "x" })).toBe(false);
+  });
+
+  it("normalizes endpoint STT/vision response shapes into capture context", async () => {
+    const stt = await withTestServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ text: "hello from endpoint", tone: { volumeRms: 0.7, paceWpm: 150 } }));
+    });
+    const vision = await withTestServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ tags: ["desk", "camera"] }));
+    });
+
+    const provider = new EndpointCaptureProvider();
+    const ctx = await provider.getContext({
+      ...defaultConfig,
+      capture: {
+        ...defaultConfig.capture,
+        useRealCapture: true,
+        sttEndpoint: stt.url,
+        visionEndpoint: vision.url,
+        visionEnabled: true,
+        visionIntervalSec: 1
+      }
+    });
+
+    expect(ctx.transcript).toContain("hello from endpoint");
+    expect(ctx.visionTags).toEqual(["desk", "camera"]);
+    await stt.close();
+    await vision.close();
   });
 });


### PR DESCRIPTION
### Motivation

- Prevent the model from fixating on raw capture telemetry (RMS/WPM) or calling out missing tags/transcript in chat output.  
- When the transcript is empty, prefer persona-led small talk instead of breaking the fourth wall about capture internals.  
- Make endpoint ingestion more robust to real STT/vision response shapes so transcripts and tags are not dropped by schema mismatches.

### Description

- Changed prompt shaping in `src/llm/realInferenceProvider.ts` so empty-transcript behavior falls back to persona-led small talk and the system prompt explicitly forbids mentioning RMS/WPM, telemetry, diagnostics, or breaking the fourth wall.  
- Replaced raw numeric tone fields sent to models with a sanitized model-facing payload via `buildModelFacingPayload` that includes `transcriptAvailable` and qualitative `tone` descriptors (`energy` / `pace`), and used that payload for both local and cloud requests.  
- Added helper functions `describeEnergy` and `describePace` to map `volumeRms`/`paceWpm` to qualitative buckets.  
- Hardened endpoint capture ingestion in `src/capture/captureProviders.ts` by adding `normalizeTranscript` and `normalizeVisionTags` to accept `transcript`, `text`, Deepgram-style nested results, and `visionTags`/`tags`, then feeding normalized values into `sharedDeviceCapturePipeline`.  
- Added integration tests in `tests/integrationRouting.test.ts` to verify the small-talk/anti-telemetry prompt behavior and the endpoint STT/vision response normalization.

### Testing

- Ran `npm test -- tests/integrationRouting.test.ts`, which passed (test file run: 16 tests passed).  
- Ran full test suite with `npm test`, which succeeded (15 test files, 66 tests passed).  
- No automated tests failed after the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6f8ac7f0883269dfa8926d8dd11e5)