### PR TITLE
Expose active model in Control Center and add verbose inference tick logging

### DIFF
--- a/src/public/app.js
+++ b/src/public/app.js
@@ -6,6 +6,7 @@ const statusBanner = document.getElementById("statusBanner");
 const runtimeSummary = document.getElementById("runtimeSummary");
 const deviceChecks = document.getElementById("deviceChecks");
 const aiHealthSummary = document.getElementById("aiHealthSummary");
+const aiActiveModelLabel = document.getElementById("aiActiveModelLabel");
 const ttsHealthSummary = document.getElementById("ttsHealthSummary");
 const sttHealthSummary = document.getElementById("sttHealthSummary");
 const liveMonitorEnabled = document.getElementById("liveMonitorEnabled");
@@ -565,9 +566,16 @@ function summarizeAiHealth(payload) {
   const health = ai.providerHealth ?? "unknown";
   const state = ai.state ?? "idle";
   const fallback = ai.fallbackMode ? ` | fallback: ${ai.fallbackMode}` : "";
+  const mode = payload?.config?.inferenceMode ?? "mock-local";
+  const resolvedPrimaryModel = mode === "openai" || mode === "groq" || mode === "mock-cloud"
+    ? payload?.config?.provider?.cloudModel
+    : payload?.config?.provider?.localModel;
+  const activeModel = ai.activeModel ?? resolvedPrimaryModel ?? "n/a";
+  if (aiActiveModelLabel) aiActiveModelLabel.textContent = `(model: ${activeModel})`;
   aiHealthSummary.textContent = [
     `AI state: ${state}`,
     `Provider health: ${health}`,
+    `Active model: ${activeModel}`,
     `Last update: ${ai.updatedAt ?? "n/a"}${fallback}`,
     `Last detail: ${ai.detail ?? "n/a"}`
   ].join("\n");

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -144,6 +144,7 @@
         <section class="control-group">
           <h3>Runtime Verification</h3>
           <pre id="runtimeSummary">Runtime status pending...</pre>
+          <p><strong>AI Health</strong> <span id="aiActiveModelLabel">(model: n/a)</span></p>
           <pre id="aiHealthSummary">AI health pending...</pre>
           <pre id="ttsHealthSummary">TTS health pending...</pre>
           <pre id="sttHealthSummary">STT health pending...</pre>

--- a/src/services/simulationOrchestrator.ts
+++ b/src/services/simulationOrchestrator.ts
@@ -1,7 +1,7 @@
 import { sharedSttEngine } from "../capture/sttEngine.js";
 import { AudioStateManager } from "../core/audioStateManager.js";
 import { applySafetyPolicy } from "../core/safetyFilter.js";
-import { ChatMessage, SimulationConfig } from "../core/types.js";
+import { ChatMessage, PromptPayload, SimulationConfig } from "../core/types.js";
 import { createInferenceProvider } from "../llm/providerFactory.js";
 import { classifyMalformedOutput, parseInferenceOutput, recommendedRecoveryAction } from "../pipeline/outputParser.js";
 import { buildPromptPayload } from "../pipeline/promptBuilder.js";
@@ -27,12 +27,14 @@ export class SimulationOrchestrator {
     state: "idle" | "running" | "degraded" | "error";
     providerHealth: "unknown" | "ok" | "degraded";
     fallbackMode: string | null;
+    activeModel: string;
     detail: string;
     updatedAt: string;
   } = {
     state: "idle",
     providerHealth: "unknown",
     fallbackMode: null,
+    activeModel: "n/a",
     detail: "Awaiting first simulation tick.",
     updatedAt: new Date().toISOString()
   };
@@ -83,12 +85,18 @@ export class SimulationOrchestrator {
     return { ...this.audioState.getState(), sttPaused: sttState.paused, sttProvider: sttState.provider };
   }
 
-  public getAiStatus(): { state: string; providerHealth: string; fallbackMode: string | null; detail: string; updatedAt: string } {
+  public getAiStatus(): { state: string; providerHealth: string; fallbackMode: string | null; activeModel: string; detail: string; updatedAt: string } {
     return { ...this.aiStatus };
   }
 
   private setAiStatus(
-    patch: Partial<{ state: "idle" | "running" | "degraded" | "error"; providerHealth: "unknown" | "ok" | "degraded"; fallbackMode: string | null; detail: string }>
+    patch: Partial<{
+      state: "idle" | "running" | "degraded" | "error";
+      providerHealth: "unknown" | "ok" | "degraded";
+      fallbackMode: string | null;
+      activeModel: string;
+      detail: string;
+    }>
   ): void {
     this.aiStatus = {
       ...this.aiStatus,
@@ -114,6 +122,37 @@ export class SimulationOrchestrator {
   private hydrateMessages(messages: ChatMessage[], source: ChatMessage["source"]): ChatMessage[] {
     const tagged = messages.map((message) => ({ ...message, source: message.source ?? source ?? "unknown" }));
     return this.identityManager.assignToMessages(tagged);
+  }
+
+  private resolveActiveModelName(config: SimulationConfig): string {
+    if (config.inferenceMode === "openai" || config.inferenceMode === "groq" || config.inferenceMode === "mock-cloud") {
+      return config.provider.cloudModel;
+    }
+    return config.provider.localModel;
+  }
+
+  private verbosePipelineLog(
+    route: "primary" | "fallback",
+    providerMode: string,
+    activeModel: string,
+    payload: PromptPayload,
+    rawInferenceResult: string
+  ): void {
+    // eslint-disable-next-line no-console
+    console.log(
+      `[SimulationOrchestrator][VerbosePipelineLog] route=${route} provider=${providerMode} model=${activeModel} transcript/visionTags + raw InferenceResult`
+    );
+    // eslint-disable-next-line no-console
+    console.log({
+      route,
+      providerMode,
+      activeModel,
+      inferencePayload: {
+        transcript: payload.context.transcript,
+        visionTags: payload.context.visionTags
+      },
+      rawInferenceResult
+    });
   }
 
   private async loop(): Promise<void> {
@@ -165,12 +204,19 @@ export class SimulationOrchestrator {
         let messages: ChatMessage[] = [];
 
         const inferenceStarted = Date.now();
-        this.setAiStatus({ state: "running", fallbackMode: null, detail: `Generating via ${config.inferenceMode}.` });
+        const activePrimaryModel = this.resolveActiveModelName(config);
+        this.setAiStatus({
+          state: "running",
+          fallbackMode: null,
+          activeModel: activePrimaryModel,
+          detail: `Generating via ${config.inferenceMode}.`
+        });
         try {
           const rawOutput = await provider.generate(payload, config, (attempt, reason) => {
             const recovery = this.cloudRecoveryMeta(attempt, config.provider.maxRetries, reason);
             this.emitMeta({ warnings: [recovery.message], cloudRecovery: recovery.phase, blocked: recovery.blocking });
           });
+          this.verbosePipelineLog("primary", config.inferenceMode, activePrimaryModel, payload, rawOutput);
           try {
             messages = this.hydrateMessages(parseInferenceOutput(rawOutput), "real-inference");
           } catch (parseError) {
@@ -196,8 +242,15 @@ export class SimulationOrchestrator {
 
           try {
             const fallbackOutput = await this.mockProvider.generate(payload, { ...config, inferenceMode: "mock-local" });
+            this.verbosePipelineLog("fallback", "mock-local", "mock-local", payload, fallbackOutput);
             messages = this.hydrateMessages(parseInferenceOutput(fallbackOutput), "fallback-mock");
-            this.setAiStatus({ state: "degraded", providerHealth: "degraded", fallbackMode: "mock-local", detail: `Primary inference failed; mock fallback active: ${reason}` });
+            this.setAiStatus({
+              state: "degraded",
+              providerHealth: "degraded",
+              fallbackMode: "mock-local",
+              activeModel: "mock-local",
+              detail: `Primary inference failed; mock fallback active: ${reason}`
+            });
             this.emitMeta({
               warnings: [reason, "Fallback engaged: mock-local"],
               dropped: false,


### PR DESCRIPTION
### Motivation
- Improve runtime visibility by surfacing the active LLM model next to AI Health so operators can see which model is active (primary or fallback).
- Add detailed per-tick pipeline logging to aid debugging by dumping the inference payload (transcript and visionTags) alongside the raw inference result and indicating whether the primary provider or fallback was used.

### Description
- Extended `SimulationOrchestrator` to track `activeModel` in `aiStatus`, exposed via `getAiStatus()` and updated when generating and when fallback engages. (`src/services/simulationOrchestrator.ts`).
- Implemented `resolveActiveModelName()` to pick cloud vs local model based on `inferenceMode`, and added `verbosePipelineLog()` which console-dumps `route` (`primary`|`fallback`), `providerMode`, `activeModel`, the payload's `transcript` and `visionTags`, and the raw inference string; called after primary and fallback `generate()` returns. (`src/services/simulationOrchestrator.ts`).
- Updated the Control Center UI to show an inline Active Model label next to AI Health and included the active model in the AI health summary block; the UI falls back to the configured primary model if `ai.activeModel` is not present. (`src/public/index.html`, `src/public/app.js`).

### Testing
- Ran a TypeScript build with `npm run build` which completed successfully.
- Ran the test suite with `npm test` (Vitest); all tests passed (66 tests, 15 files) and the test run completed without failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6fe006708832696c3e5f561cfc12f)