### PR TITLE
Refocus system prompt on most recent 10s of transcript

### DIFF
--- a/src/llm/realInferenceProvider.ts
+++ b/src/llm/realInferenceProvider.ts
@@ -106,7 +106,7 @@ function extractProviderText(data: ProviderResponseShape): string {
 function systemPromptForPayload(payload: PromptPayload): string {
   const transcript = payload.context.transcript.trim();
   const transcriptDirective = transcript
-    ? `Highest priority: react directly to the streamer's latest words from context.transcript ("${transcript.slice(0, 220)}").`
+    ? `Highest priority: react directly to the streamer's latest words from context.transcript ("${transcript.slice(0, 220)}"). Prioritize the most recent ~10 seconds (the tail end of context.transcript) as the primary signal, and use earlier transcript lines only as background context.`
     : "No transcript text is available right now. Fall back to persona-led small talk and channel chatter topics without claiming missing feeds or missing tags.";
   const questionDirective = transcript && /\?/.test(transcript)
     ? "The transcript includes a question; at least one message must directly answer or acknowledge that question."

--- a/tests/integrationRouting.test.ts
+++ b/tests/integrationRouting.test.ts
@@ -359,6 +359,7 @@ describe("hybrid routing and failover", () => {
         const userPayload = JSON.parse(parsed.messages[1]?.content as string);
 
         expect(systemPrompt).toMatch(/react directly to the streamer's latest words/i);
+        expect(systemPrompt).toMatch(/Prioritize the most recent ~10 seconds/i);
         expect(systemPrompt).toMatch(/Do not output generic filler/i);
         expect(systemPrompt).toMatch(/60%\+ of messages must be under 5 words/i);
         expect(systemPrompt).toMatch(/drop F in chat|spam W|type yes\/no/i);


### PR DESCRIPTION
### Motivation
- Make the LLM system prompt explicitly instruct the model to prioritize the most recent ~10 seconds of `context.transcript` as the primary signal and treat earlier transcript lines as background context while keeping the existing 90s capture window.

### Description
- Update `systemPromptForPayload` in `src/llm/realInferenceProvider.ts` to append: "Prioritize the most recent ~10 seconds (the tail end of context.transcript) as the primary signal, and use earlier transcript lines only as background context." and add a matching assertion to `tests/integrationRouting.test.ts` to verify the new wording is present.

### Testing
- Ran `npm test -- tests/integrationRouting.test.ts` and the test suite passed (`16 tests` all green).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c710579b188326a1f9e1eaed3919c2)