### PR TITLE
Harden chat JSON schema and recency handling

### DIFF
--- a/src/capture/deviceCapturePipeline.ts
+++ b/src/capture/deviceCapturePipeline.ts
@@ -15,7 +15,7 @@ interface VisionSample {
 
 export class DeviceCapturePipeline {
   private readonly micFrames: MicFrame[] = [];
-  private readonly transcriptWindowMs = 90_000;
+  private readonly transcriptWindowMs = 20_000;
   private lastVisionSample: VisionSample | null = null;
   private micPaused = false;
 
@@ -46,6 +46,7 @@ export class DeviceCapturePipeline {
     this.pruneOldMicFrames();
 
     const transcript = this.micFrames
+      .filter((frame) => Date.now() - frame.capturedAt <= 10_000)
       .map((frame) => frame.transcriptChunk)
       .filter(Boolean)
       .join(" ")

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -99,8 +99,8 @@ export interface ChatMessage {
   username: string;
   text: string;
   emotes: string[];
-  donationCents?: number;
-  ttsText?: string;
+  donationCents?: number | null;
+  ttsText?: string | null;
   createdAt: string;
   source?: MessageSource;
 }
@@ -118,8 +118,8 @@ export interface QueueMessage {
   payload: {
     text: string;
     emotes: string[];
-    donationCents?: number;
-    ttsText?: string;
+    donationCents?: number | null;
+    ttsText?: string | null;
   };
   moderation: {
     safetyAction: "pass" | "drop" | "censor";

--- a/src/llm/mockAudienceGenerator.ts
+++ b/src/llm/mockAudienceGenerator.ts
@@ -6,7 +6,7 @@ const supportive = ["Let's go!", "Huge improvement today", "W gameplay", "You're
 const trolls = ["That was rough", "Skill issue", "Chat is carrying", "No way you missed that"];
 const neutral = ["What build is this?", "Any tips for new players?", "What's next?", "Clean reset"];
 const memes = ["PogChamp", "W stream", "clip it", "we're so back"];
-const emotePool = ["🔥", "😂", "👏", "Pog", "W", "LUL", "Kappa"];
+const emotePool = ["🔥", "😂", "👏", "W", "LUL", "Kappa", "PogChamp", "monkaS", "OMEGALUL", "L"];
 
 function pick<T>(arr: T[]): T {
   return arr[Math.floor(Math.random() * arr.length)];
@@ -41,12 +41,17 @@ function engagementFromSignals(config: SimulationConfig, context: StreamContext,
   return Math.min(1.7, 0.55 + features.excitementScore * 0.72 + features.personaBiasScore * 0.2 + conditioning.expressiveness * 0.15);
 }
 
-function realisticDonation(config: SimulationConfig, tone: ToneSnapshot, conditioning: ProviderConditioning, context?: StreamContext): { donationCents?: number; ttsText?: string } {
+function realisticDonation(
+  config: SimulationConfig,
+  tone: ToneSnapshot,
+  conditioning: ProviderConditioning,
+  context?: StreamContext
+): { donationCents: number | null; ttsText: string | null } {
   const safeContext = context ?? { transcript: "", tone, visionTags: [], timestamp: new Date().toISOString() };
   const features = realismModel.extract(safeContext, config.persona);
   const engagement = engagementFromSignals(config, safeContext, conditioning);
   const effectiveRate = Math.min(0.85, config.donationFrequency * engagement * (0.42 + features.donationPropensity) * (0.7 + conditioning.expressiveness * 0.4));
-  if (Math.random() >= effectiveRate) return {};
+  if (Math.random() >= effectiveRate) return { donationCents: null, ttsText: null };
 
   const base = 100 + Math.floor(Math.random() * 900);
   const hypeMultiplier = features.excitementScore > 0.75 || tone.paceWpm > 170 ? 3 : features.excitementScore > 0.55 ? 2 : 1;
@@ -55,7 +60,7 @@ function realisticDonation(config: SimulationConfig, tone: ToneSnapshot, conditi
   const ttsPrefix = tone.volumeRms > 0.5 ? "YO" : "hey";
   return {
     donationCents,
-    ttsText: config.ttsEnabled && config.ttsMode !== "off" ? `${ttsPrefix} streamer this is fire. ${context?.transcript.slice(0, 60) ?? "great run"}` : undefined
+    ttsText: config.ttsEnabled && config.ttsMode !== "off" ? `${ttsPrefix} streamer this is fire. ${context?.transcript.slice(0, 60) ?? "great run"}` : null
   };
 }
 
@@ -76,6 +81,8 @@ export function generateAudienceBatch(config: SimulationConfig, tone: ToneSnapsh
       username: mockIdentityManager.getIdentity(),
       text: withBias(text, config.bias === "split" && features.personaBiasScore < 0.45 ? "disagree" : config.bias, conditioning, personaCalibration.contrarianism),
       emotes: Math.random() > 0.45 ? [pick(emotePool)] : [],
+      donationCents: null,
+      ttsText: null,
       createdAt: new Date().toISOString(),
       source: "mock-audience"
     };

--- a/src/llm/realInferenceProvider.ts
+++ b/src/llm/realInferenceProvider.ts
@@ -66,6 +66,47 @@ type ProviderResponseShape = {
   }>;
 };
 
+const ALLOWED_TEXT_EMOTES = ["Kappa", "LUL", "PogChamp", "OMEGALUL", "monkaS", "W", "L"] as const;
+
+function openAiResponseSchema() {
+  return {
+    type: "json_schema",
+    json_schema: {
+      name: "streamsim_chat_batch",
+      strict: true,
+      schema: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          messages: {
+            type: "array",
+            minItems: 1,
+            items: {
+              type: "object",
+              additionalProperties: false,
+              properties: {
+                text: { type: "string" },
+                emotes: {
+                  type: "array",
+                  items: { type: "string" }
+                },
+                donationCents: {
+                  anyOf: [{ type: "integer", minimum: 1 }, { type: "null" }]
+                },
+                ttsText: {
+                  anyOf: [{ type: "string" }, { type: "null" }]
+                }
+              },
+              required: ["text", "emotes", "donationCents", "ttsText"]
+            }
+          }
+        },
+        required: ["messages"]
+      }
+    }
+  } as const;
+}
+
 function extractTextFromContentParts(
   parts: Array<{ type?: string; text?: string | { value?: string } }> | undefined
 ): string | null {
@@ -113,23 +154,28 @@ function systemPromptForPayload(payload: PromptPayload): string {
     : "If no question is present in the transcript, avoid inventing one.";
 
   return [
-    'Return strict JSON only: {"messages":[{"text":"string","emotes":["string"],"donationCents":number?,"ttsText":"string?"}]}. Never include usernames.',
+    'Return strict JSON only: {"messages":[{"text":"string","emotes":["string"],"donationCents":number|null,"ttsText":string|null}]}. Never include usernames.',
     "You are simulating a live audience reacting to the streamer in real time (not a generic standalone chat).",
     transcriptDirective,
     questionDirective,
+    "ROLE: you are the audience. The transcript is what you heard from the streamer, not what you should say.",
+    "CRITICAL: never mirror the streamer's exact question text back to chat. If streamer asks 'can you hear me?', answer it as audience (example: 'yep loud and clear').",
+    "Do not quote the streamer's exact wording unless you are intentionally making a joke/meme about it.",
     "Treat context.transcript as more important than persona flavor text when they conflict.",
     "At least 55% of messages must reference specific transcript/tone/vision details; the rest can be side-convos, memes, or crowd noise.",
     "Do not simply repeat or lightly rephrase the streamer's words back to them.",
     "Use rapid-fire Twitch-style pacing: 60%+ of messages must be under 5 words.",
     "Keep most messages short fragments, meme slang, or reactions like 'W', 'LMAO', 'ratio', 'wait what?', 'nah', 'cooked'.",
     "If the streamer gives a clear chat command (examples: 'drop F in chat', 'spam W', 'type yes/no'), many messages should follow that command literally.",
+    `Emotes rule: emotes array may contain only unicode emoji or one of [${ALLOWED_TEXT_EMOTES.join(", ")}]. Never invent emote names.`,
     "Some viewers should be emote-only (message text can be empty while emotes are populated).",
     "Do not feel obligated to acknowledge every streamer line; realistic chats often drift into side chatter.",
     "React to the stream context like a real viewer with casual slang and natural chat energy.",
     "Never mention RMS, WPM, telemetry, diagnostics, pipelines, or whether tags/transcript are missing.",
     "Do not break the fourth wall by discussing system input quality or capture internals.",
     "Do not output generic filler like 'positive vibes', 'keep it up', or cheerleading with no context anchors.",
-    "Supportive persona means kind tone, not generic praise; keep every message situational and reactive."
+    "Supportive persona means kind tone, not generic praise; keep every message situational and reactive.",
+    "Only set ttsText when donationCents is a positive number. Otherwise ttsText must be null."
   ].join(" ");
 }
 
@@ -308,12 +354,16 @@ export class HybridInferenceProvider implements InferenceProvider {
         model: string;
         temperature?: number;
         messages: Array<{ role: "system" | "user"; content: string }>;
+        response_format?: ReturnType<typeof openAiResponseSchema>;
       } = {
         model,
         messages
       };
       if (cloudModelSupportsTemperature(model)) {
         body.temperature = 0.8;
+      }
+      if (this.mode === "openai") {
+        body.response_format = openAiResponseSchema();
       }
 
       let response: Response;

--- a/src/pipeline/outputParser.ts
+++ b/src/pipeline/outputParser.ts
@@ -3,6 +3,21 @@ import { ChatMessage } from "../core/types.js";
 export type MalformedOutputClass = "empty" | "no_json_object" | "json_syntax" | "missing_messages" | "invalid_message_schema";
 export type RecoveryAction = "repair" | "regenerate" | "drop";
 const MAX_INFERENCE_OUTPUT_CHARS = 250_000;
+const ALLOWED_TEXT_EMOTES = new Set(["Kappa", "LUL", "PogChamp", "OMEGALUL", "monkaS", "W", "L"]);
+const UNICODE_EMOJI_PATTERN = /\p{Extended_Pictographic}/u;
+
+function isAllowedEmote(value: string): boolean {
+  const trimmed = value.trim();
+  return ALLOWED_TEXT_EMOTES.has(trimmed) || UNICODE_EMOJI_PATTERN.test(trimmed);
+}
+
+function normalizeTtsText(candidate: Record<string, unknown>, donationCents: number | null): string | undefined {
+  if (candidate.ttsText === null) return undefined;
+  if (typeof candidate.ttsText !== "string") return undefined;
+  const trimmed = candidate.ttsText.trim();
+  if (!trimmed) return undefined;
+  return donationCents && donationCents > 0 ? trimmed : undefined;
+}
 
 function coerceMessage(raw: unknown): ChatMessage | null {
   if (typeof raw !== "object" || raw === null) return null;
@@ -10,15 +25,22 @@ function coerceMessage(raw: unknown): ChatMessage | null {
 
   if (typeof candidate.text !== "string") return null;
   if (!Array.isArray(candidate.emotes) || !candidate.emotes.every((item) => typeof item === "string")) return null;
+  if (!Object.prototype.hasOwnProperty.call(candidate, "donationCents")) return null;
+  if (!Object.prototype.hasOwnProperty.call(candidate, "ttsText")) return null;
+  if (!(candidate.donationCents === null || typeof candidate.donationCents === "number")) return null;
+  if (!(candidate.ttsText === null || typeof candidate.ttsText === "string")) return null;
+
+  const donationCents = typeof candidate.donationCents === "number" && candidate.donationCents > 0 ? Math.floor(candidate.donationCents) : null;
+  const emotes = candidate.emotes.map((emote) => emote.trim()).filter((emote) => isAllowedEmote(emote));
 
   return {
     id: typeof candidate.id === "string" ? candidate.id : `${Date.now()}-${Math.random().toString(16).slice(2)}`,
     username: typeof candidate.username === "string" ? candidate.username : "",
     text: candidate.text,
-    emotes: candidate.emotes,
+    emotes,
     createdAt: typeof candidate.createdAt === "string" ? candidate.createdAt : new Date().toISOString(),
-    donationCents: typeof candidate.donationCents === "number" ? candidate.donationCents : undefined,
-    ttsText: typeof candidate.ttsText === "string" ? candidate.ttsText : undefined,
+    donationCents: donationCents ?? undefined,
+    ttsText: normalizeTtsText(candidate, donationCents),
     source:
       candidate.source === "real-inference" ||
       candidate.source === "mock-inference" ||

--- a/tests/pipeline.test.ts
+++ b/tests/pipeline.test.ts
@@ -30,7 +30,7 @@ describe("runtime config", () => {
 
 describe("output parser", () => {
   it("repairs fenced JSON payload and returns messages", () => {
-    const repaired = repairInferenceOutput(`###json\n{"messages":[{"username":"a","text":"hi","emotes":[]}]}\n###`);
+    const repaired = repairInferenceOutput(`###json\n{"messages":[{"username":"a","text":"hi","emotes":[],"donationCents":null,"ttsText":null}]}\n###`);
     const result = parseInferenceOutput(repaired);
     expect(result).toHaveLength(1);
     expect(result[0].username).toBe("a");
@@ -38,7 +38,7 @@ describe("output parser", () => {
 
 
   it("accepts messages without username for local identity assignment", () => {
-    const result = parseInferenceOutput('{"messages":[{"text":"hi","emotes":[]}]}');
+    const result = parseInferenceOutput('{"messages":[{"text":"hi","emotes":[],"donationCents":null,"ttsText":null}]}');
     expect(result).toHaveLength(1);
     expect(result[0].username).toBe("");
   });
@@ -48,12 +48,20 @@ describe("output parser", () => {
   });
 
   it("classifies recoverable fenced JSON noise as syntax-repairable", () => {
-    const malformed = "noise ###json\n{\"messages\":[{\"text\":\"yo\",\"emotes\":[]}]}### trailing";
+    const malformed = "noise ###json\n{\"messages\":[{\"text\":\"yo\",\"emotes\":[],\"donationCents\":null,\"ttsText\":null}]}### trailing";
     expect(classifyMalformedOutput(malformed)).toBe("json_syntax");
   });
 
   it("caps oversized payloads to avoid parser stalls and still throws cleanly", () => {
-    const huge = `${"x".repeat(300_000)}{"messages":[{"text":"ok","emotes":[]}]}`;
+    const huge = `${"x".repeat(300_000)}{"messages":[{"text":"ok","emotes":[],"donationCents":null,"ttsText":null}]}`;
     expect(() => parseInferenceOutput(huge)).toThrow();
+  });
+
+  it("filters unsupported emote strings and suppresses ttsText without donation", () => {
+    const result = parseInferenceOutput(
+      '{"messages":[{"text":"yo","emotes":["W","LetMeCook","🔥"],"donationCents":null,"ttsText":"read this"}]}'
+    );
+    expect(result[0].emotes).toEqual(["W", "🔥"]);
+    expect(result[0].ttsText).toBeUndefined();
   });
 });


### PR DESCRIPTION
### Motivation
- Fix inconsistent/missing output fields and formatting by enforcing a strict response schema so downstream code always receives `text`, `emotes`, `donationCents`, and `ttsText` keys.
- Prevent emote hallucination and mixed-emote styles by constraining allowed emotes and filtering unapproved tokens.
- Reduce recency bias where the model reacts to stale transcript lines by narrowing the capture window and prompting the model to prioritize the most recent speech.
- Limit TTS spam by gating `ttsText` generation to actual donations and stop the model from parroting streamer text.

### Description
- Added an OpenAI `response_format` JSON schema and stronger system-prompt directives in `src/llm/realInferenceProvider.ts` to require nullable `donationCents`/`ttsText`, enforce audience perspective, anti-echo rules, emote constraints, and TTS gating (`openAiResponseSchema` and updated `systemPromptForPayload`).
- Hardened parser validation in `src/pipeline/outputParser.ts` to require the presence of `donationCents` and `ttsText` keys, validate null-or-type, normalize/suppress `ttsText` unless `donationCents` > 0, and filter emotes to an approved set or unicode emoji.
- Tightened capture recency in `src/capture/deviceCapturePipeline.ts` by reducing the transcript window and assembling transcript text only from the most recent 10 seconds to keep model inputs fresh.
- Updated mocks and types for schema consistency by making `donationCents`/`ttsText` nullable in `src/core/types.ts` and ensuring `src/llm/mockAudienceGenerator.ts` emits nullable fields and only approved emotes.
- Expanded `tests/pipeline.test.ts` to assert the new required nullable fields, emote filtering, and TTS suppression behavior.

### Testing
- Built the project with `npm run build` and the TypeScript build completed successfully.
- Ran the focused test suite with `npm run test -- tests/pipeline.test.ts` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7d3a8897c832696bc068b6652242d)