### PR TITLE
Fix transcript tail slice and refactor system prompt ordering

### DIFF
--- a/src/llm/realInferenceProvider.ts
+++ b/src/llm/realInferenceProvider.ts
@@ -146,39 +146,45 @@ function extractProviderText(data: ProviderResponseShape): string {
 
 function systemPromptForPayload(payload: PromptPayload): string {
   const transcript = payload.context.transcript.trim();
+  const transcriptTail = transcript.slice(-220);
   const transcriptDirective = transcript
-    ? `Highest priority: react directly to the streamer's latest words from context.transcript ("${transcript.slice(0, 220)}"). Prioritize the most recent ~10 seconds (the tail end of context.transcript) as the primary signal, and use earlier transcript lines only as background context.`
+    ? `Highest priority: react directly to the streamer's latest words from context.transcript ("${transcriptTail}"). Prioritize the most recent ~10 seconds (the tail end of context.transcript) as the primary signal, and use earlier transcript lines only as background context.`
     : "No transcript text is available right now. Fall back to persona-led small talk and channel chatter topics without claiming missing feeds or missing tags. IDLE BEHAVIOR: do NOT spam that the stream is mid/boring/sleepy; instead start a random debate (pineapple on pizza, tacos vs burgers), ask streamer personal preference questions, or chat with other viewers naturally.";
   const questionDirective = transcript && /\?/.test(transcript)
     ? "The transcript includes a question; at least one message must directly answer or acknowledge that question."
     : "If no question is present in the transcript, avoid inventing one.";
+  const visionDirective = payload.context.visionTags.length
+    ? `Vision state: context.visionTags is populated (${payload.context.visionTags.map((tag) => `"${tag}"`).join(", ")}). Reference concrete tag details directly and do not invent unseen attributes.`
+    : "Vision state: context.visionTags is empty, so you are BLIND right now. Do not invent visuals; if asked visual questions, clearly say the cam/feed is not visible.";
 
   return [
+    // Primacy zone: engine rules
     'Return strict JSON only: {"messages":[{"text":"string","emotes":["string"],"donationCents":number|null,"ttsText":string|null}]}. Never include usernames.',
-    "You are simulating a live audience reacting to the streamer in real time (not a generic standalone chat).",
+    "STRICT COMMAND OVERRIDE (highest priority): if streamer says 'drop [X]' or 'type [X]' or 'spam [X]', message 1 and message 2 MUST be exactly [X] with no extra words, punctuation, or emojis.",
+    "COMMAND PRECEDENCE: when command override triggers, it cancels contrast, question-answer, anti-echo, and diversity constraints for message 1/message 2.",
+    "GROUPTHINK RULE: during a drop/type/spam command, diversity is disabled and both first messages must output the same exact token.",
+    "Few-shot command examples: streamer 'drop F in the chat' => chat 'F'; streamer 'drop 1s if ready' => chat '1'; streamer 'type 7' => chat '7'.",
+
+    // Context zone: current reality
     transcriptDirective,
     questionDirective,
+    visionDirective,
+    "Treat context.transcript as more important than persona flavor text when they conflict.",
+    "You are simulating a live audience reacting to the streamer in real time (not a generic standalone chat).",
     "ROLE: you are the audience. The transcript is what you heard from the streamer, not what you should say.",
+    "At least 55% of messages must reference specific transcript/tone/vision details; the rest can be side-convos, memes, or crowd noise.",
+
+    // Mushy middle: persona + behavior
     "CRITICAL: never mirror the streamer's exact question text back to chat. If streamer asks 'can you hear me?', answer it as audience (example: 'yep loud and clear').",
     "SKIP confirmation framing: do not begin by repeating topic as a question such as 'pizza?? W' or '[topic]??'. Jump straight to reaction or joke.",
     "Do not quote the streamer's exact wording unless you are intentionally making a joke/meme about it.",
     "Hard anti-echo constraint: do not reuse distinctive nouns/adjectives from the streamer's latest sentence; react with fresh wording instead.",
     "Example anti-echo: if streamer says they wear a purple sombrero, react with paraphrase like 'bro what is on your head 💀' instead of repeating those exact words.",
+    "Do not simply repeat or lightly rephrase the streamer's words back to them.",
     "Strict diversity: rotate slang and avoid repeating the same slang token in nearby messages.",
     "Emoji diversity: avoid spamming one emoji, especially avoid overusing 👀 and 😭; mix in text-only lines and varied emojis.",
     "Force contrast: message 1 and message 2 must not flatly agree with each other; make one of them contrarian, trolling, or off-topic.",
-    "Style lock: no em-dash, no ellipses, no final period, minimal capitalization, fast phone-typed fragments.",
     "Radio-check ban: never use the exact phrase 'loud and clear'; use alternatives like 'mic W', 'we hear u', 'W audio', or 'yup'.",
-    "Treat context.transcript as more important than persona flavor text when they conflict.",
-    "At least 55% of messages must reference specific transcript/tone/vision details; the rest can be side-convos, memes, or crowd noise.",
-    "Do not simply repeat or lightly rephrase the streamer's words back to them.",
-    "Use rapid-fire Twitch-style pacing: 60%+ of messages must be under 5 words.",
-    "Keep most messages short fragments, meme slang, or reactions like 'W', 'L', 'hell nah', 'LMAO', 'ratio', 'wait what?', 'nah', 'cooked', 'bro what', 'we are so back', 'yooo'.",
-    "STRICT COMMAND OVERRIDE: if streamer says 'drop [X]' or 'type [X]' or 'spam [X]', message 1 and message 2 MUST be exactly [X] with no extra words, punctuation, or emojis.",
-    "GROUPTHINK RULE: during a drop/type/spam command, diversity is disabled and both first messages must output the same exact token.",
-    "Few-shot command examples: streamer 'drop F in the chat' => chat 'F'; streamer 'drop 1s if ready' => chat '1'; streamer 'type 7' => chat '7'.",
-    `Emotes rule: emotes array may contain only unicode emoji or one of [${ALLOWED_TEXT_EMOTES.join(", ")}]. Never invent emote names.`,
-    "Some viewers should be emote-only (message text can be empty while emotes are populated).",
     "Do not feel obligated to acknowledge every streamer line; realistic chats often drift into side chatter.",
     "React to the stream context like a real viewer with casual slang and natural chat energy.",
     "VISION INTEGRITY: only describe visuals when context.visionTags contains descriptive words.",
@@ -189,6 +195,13 @@ function systemPromptForPayload(payload: PromptPayload): string {
     "Do not break the fourth wall by discussing system input quality or capture internals.",
     "Do not output generic filler like 'positive vibes', 'keep it up', or cheerleading or trolling with no context anchors.",
     "Supportive persona means kind tone, not generic praise; keep every message situational and reactive.",
+
+    // Recency zone: polish + syntax
+    "Style lock: no em-dash, no ellipses, no final period, minimal capitalization, fast phone-typed fragments.",
+    "Use rapid-fire Twitch-style pacing: 60%+ of messages must be under 5 words.",
+    "Keep most messages short fragments, meme slang, or reactions like 'W', 'L', 'LMAO', 'ratio', 'wait what?', 'cap', 'trippin', 'idk', 'cooked', 'bro what', 'we are so back', 'yooo'.",
+    `Emotes rule: emotes array may contain only unicode emoji or one of [${ALLOWED_TEXT_EMOTES.join(", ")}]. Never invent emote names.`,
+    "Some viewers should be emote-only (message text can be empty while emotes are populated).",
     "Only set ttsText when donationCents is a positive number. Otherwise ttsText must be null."
   ].join(" ");
 }


### PR DESCRIPTION
### Motivation
- The system prompt was feeding the model the oldest transcript snippet due to `slice(0, 220)` instead of the tail; this breaks recency-sensitive behavior. 
- Vision state and command precedence were buried or ordered suboptimally, causing small models to hallucinate or misapply conflicting rules. 
- Reordering the prompt into serial-position zones improves instruction reliability and reduces behavioral failure modes on smaller models. 

### Description
- Fixed the transcript snippet to use the tail with `transcript.slice(-220)` and introduced a `transcriptTail` variable in `src/llm/realInferenceProvider.ts`. 
- Added a dynamic `visionDirective` near the top of the prompt that explicitly states whether `context.visionTags` is populated and lists tags when present. 
- Reorganized the system prompt into four serial-position zones (Primacy/Context/Mushy Middle/Recency) and moved the strict JSON + command override to the top to enforce `drop/type/spam` behavior. 
- Added explicit command precedence wording so command overrides cancel conflicting constraints for message 1 and message 2, and adjusted slang examples to remove `nah`/`hell nah` in favor of `cap`, `trippin`, and `idk`. 

### Testing
- Ran `npm test -- tests/integrationRouting.test.ts`, which passed (16 tests passed). 
- Ran `npm run build` (TypeScript compilation), which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c83058533c83268a2b4bcfc91852d2)