### PR TITLE
Add vision pipeline diagnostics and improve caption-to-tag parsing

### DIFF
--- a/src/capture/captureProviders.ts
+++ b/src/capture/captureProviders.ts
@@ -41,11 +41,29 @@ function normalizeVisionTags(payload: JsonCaptureResponse): string[] {
   const caption = captionCandidates.find((value): value is string => typeof value === "string" && value.trim().length > 0);
   if (!caption) return [];
 
-  return caption
+  const commaDelimited = caption
     .split(/[|,;\n]/g)
     .map((part) => part.trim())
     .filter(Boolean)
     .slice(0, 8);
+  if (commaDelimited.length > 1) return commaDelimited;
+
+  const phraseSeed = caption
+    .toLowerCase()
+    .replace(/\b(i can see|looks like|there is|there's|showing|appears to be)\b/g, "")
+    .replace(/[.!?]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (!phraseSeed) return [];
+
+  const descriptorCandidates = phraseSeed
+    .split(/\b(?:and|with|while|near|next to|in front of|beside|on top of|over)\b/gi)
+    .map((part) => part.trim())
+    .filter((part) => part.length >= 3)
+    .map((part) => part.replace(/^(a|an|the)\s+/i, "").trim())
+    .slice(0, 8);
+
+  return descriptorCandidates.length > 1 ? descriptorCandidates : [caption.trim()].filter(Boolean);
 }
 
 export class MockCaptureProvider implements CaptureProvider {
@@ -84,6 +102,13 @@ export class EndpointCaptureProvider implements CaptureProvider {
 
     const sttData = ((sttRes && sttRes.ok ? await sttRes.json() : {}) ?? {}) as JsonCaptureResponse;
     const visionData = ((visionRes && visionRes.ok ? await visionRes.json() : {}) ?? {}) as JsonCaptureResponse;
+    // eslint-disable-next-line no-console
+    console.log("[VisionCapture] Vision API call resolved", {
+      endpoint: config.capture.visionEndpoint,
+      ok: Boolean(visionRes?.ok),
+      status: visionRes?.status ?? null,
+      hasPayload: Object.keys(visionData).length > 0
+    });
 
     const transcript = normalizeTranscript(sttData);
     if (transcript) {
@@ -94,6 +119,8 @@ export class EndpointCaptureProvider implements CaptureProvider {
       });
     }
     const visionTags = normalizeVisionTags(visionData);
+    // eslint-disable-next-line no-console
+    console.log("[VisionCapture] Parsed vision tags array", { visionTags });
     if (visionTags.length) {
       sharedDeviceCapturePipeline.ingestVisionSample({ tags: visionTags });
     }

--- a/src/capture/deviceCapturePipeline.ts
+++ b/src/capture/deviceCapturePipeline.ts
@@ -40,6 +40,8 @@ export class DeviceCapturePipeline {
   public ingestVisionSample(sample: { tags?: string[] }): void {
     const tags = Array.isArray(sample.tags) ? sample.tags.filter((tag) => typeof tag === "string" && tag.trim().length > 0).slice(0, 8) : [];
     this.lastVisionSample = { tags, capturedAt: Date.now() };
+    // eslint-disable-next-line no-console
+    console.log("[DeviceCapturePipeline] Saved latest vision tags", { tags, capturedAt: this.lastVisionSample.capturedAt });
   }
 
   public getContext(config: SimulationConfig): StreamContext {
@@ -54,6 +56,12 @@ export class DeviceCapturePipeline {
     const tone = this.computeTone();
     const now = Date.now();
     const visionTags = config.capture.visionEnabled && this.lastVisionSample ? this.lastVisionSample.tags : [];
+    // eslint-disable-next-line no-console
+    console.log("[DeviceCapturePipeline] Returning context with latest saved vision tags", {
+      visionEnabled: config.capture.visionEnabled,
+      hasVisionSample: Boolean(this.lastVisionSample),
+      visionTags
+    });
 
     return {
       transcript,

--- a/src/services/simulationOrchestrator.ts
+++ b/src/services/simulationOrchestrator.ts
@@ -237,13 +237,16 @@ export class SimulationOrchestrator {
       `[SimulationOrchestrator][VerbosePipelineLog] route=${route} provider=${providerMode} model=${activeModel} transcript/visionTags + raw InferenceResult`
     );
     // eslint-disable-next-line no-console
+    console.log("[SimulationOrchestrator] currentVisionTags before inferencePayload build", payload.context.visionTags);
+    const currentVisionTags = payload.context.visionTags;
+    // eslint-disable-next-line no-console
     console.log({
       route,
       providerMode,
       activeModel,
       inferencePayload: {
         transcript: payload.context.transcript,
-        visionTags: payload.context.visionTags
+        visionTags: currentVisionTags
       },
       rawInferenceResult
     });

--- a/tests/captureProviders.test.ts
+++ b/tests/captureProviders.test.ts
@@ -58,4 +58,30 @@ describe("EndpointCaptureProvider", () => {
 
     expect(context.visionTags).toEqual(["game HUD", "red warning light", "inventory panel"]);
   });
+
+  it("parses plain-language vision descriptions into descriptor arrays", async () => {
+    const provider = new EndpointCaptureProvider();
+    const config = {
+      ...defaultConfig,
+      capture: {
+        ...defaultConfig.capture,
+        visionIntervalSec: 5
+      }
+    };
+
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes("/stt")) {
+        return { ok: true, json: async () => ({ transcript: "sup chat" }) } as Response;
+      }
+      return {
+        ok: true,
+        json: async () => ({ description: "A man in a red shirt sitting in a chair and a bright ring light behind him." })
+      } as Response;
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const context = await provider.getContext(config);
+
+    expect(context.visionTags).toEqual(["man in a red shirt sitting in a chair", "bright ring light behind him"]);
+  });
 });


### PR DESCRIPTION
### Motivation

- Make it observable when the vision endpoint (GPT Vision) actually returns a payload so we can verify the API call completes.
- Ensure freeform/sentence-style vision text is parsed into an array of descriptors (`visionTags: string[]`) instead of a single collapsed string.
- Confirm the vision tags are persisted into the shared capture state and available when `inferencePayload` is assembled to avoid timing/state drop-off between slow vision calls and fast STT.

### Description

- Improve caption fallback parsing in `normalizeVisionTags` to split plain-language sentences into descriptor candidates and return multiple tags where appropriate (file: `src/capture/captureProviders.ts`).
- Add post-resolution diagnostics to the endpoint capture path with a log showing endpoint, HTTP status, and whether a payload is present (file: `src/capture/captureProviders.ts`).
- Log the parsed `visionTags` array immediately before ingesting into the shared pipeline and add persistence visibility logs in `DeviceCapturePipeline` when samples are saved and when context is returned (file: `src/capture/deviceCapturePipeline.ts`).
- Add a `console.log` in `SimulationOrchestrator` showing `currentVisionTags` right before `inferencePayload` is logged/assembled (file: `src/services/simulationOrchestrator.ts`).
- Add a unit test that verifies sentence-style vision descriptions are parsed into multiple descriptor tags (file: `tests/captureProviders.test.ts`).

### Testing

- Ran `npm test -- tests/captureProviders.test.ts` and the test file passed (`3 tests` all passed).
- Ran `npm run build` and TypeScript build completed successfully without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c88352220c83268d7cb94d16f8b9c3)