### PR TITLE
Improve transcript lull handling and topic persistence

### DIFF
--- a/src/capture/deviceCapturePipeline.ts
+++ b/src/capture/deviceCapturePipeline.ts
@@ -48,7 +48,7 @@ export class DeviceCapturePipeline {
     this.pruneOldMicFrames();
 
     const transcript = this.micFrames
-      .filter((frame) => Date.now() - frame.capturedAt <= 10_000)
+      .filter((frame) => Date.now() - frame.capturedAt <= this.transcriptWindowMs)
       .map((frame) => frame.transcriptChunk)
       .filter(Boolean)
       .join(" ")

--- a/src/config/runtimeConfig.ts
+++ b/src/config/runtimeConfig.ts
@@ -1,6 +1,7 @@
 import { SimulationConfig } from "../core/types.js";
 
 export const defaultConfig: SimulationConfig = {
+  streamTopic: "Just Chatting",
   viewerCount: 100,
   engagementMultiplier: 1,
   slowMode: false,
@@ -69,6 +70,7 @@ export function sanitizeConfig(input: unknown): SimulationConfig {
   const inferenceMode = candidate.inferenceMode;
 
   return {
+    streamTopic: asString(candidate.streamTopic, defaultConfig.streamTopic),
     viewerCount: Math.max(1, Math.min(50000, Math.floor(asNumber(candidate.viewerCount, defaultConfig.viewerCount)))),
     engagementMultiplier: Math.max(0.1, Math.min(5, asNumber(candidate.engagementMultiplier, defaultConfig.engagementMultiplier))),
     slowMode: asBoolean(candidate.slowMode, defaultConfig.slowMode),

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -52,6 +52,7 @@ export interface SecurityConfig {
 }
 
 export interface SimulationConfig {
+  streamTopic: string;
   viewerCount: number;
   engagementMultiplier: number;
   slowMode: boolean;
@@ -86,6 +87,7 @@ export interface PromptPayload {
   bias: BiasMode;
   emoteOnly: boolean;
   viewerCount: number;
+  streamTopic?: string;
   context: StreamContext;
   requestedMessageCount: number;
   personaCalibration: PersonaCalibration;

--- a/src/llm/realInferenceProvider.ts
+++ b/src/llm/realInferenceProvider.ts
@@ -150,9 +150,10 @@ function systemPromptForPayload(payload: PromptPayload): string {
   const transcriptTail = rawTranscriptTail.includes(" ")
     ? rawTranscriptTail.slice(rawTranscriptTail.indexOf(" ") + 1)
     : rawTranscriptTail;
+  const streamTopic = String(payload.streamTopic ?? "").trim() || "Just Chatting";
   const transcriptDirective = transcript
-    ? `Highest priority: react directly to the streamer's latest words from context.transcript ("${transcriptTail}"). Prioritize the most recent ~10 seconds (the tail end of context.transcript) as the primary signal, and use earlier transcript lines only as background context.`
-    : "No transcript text is available right now. Fall back to persona-led small talk and channel chatter topics without claiming missing feeds or missing tags. IDLE BEHAVIOR: do NOT spam that the stream is mid/boring/sleepy; instead start a random debate (pineapple on pizza, tacos vs burgers), ask streamer personal preference questions, or chat with other viewers naturally.";
+    ? `Highest priority: react directly to the streamer's words: "${transcriptTail}". Prioritize the most recent ~10 seconds (the tail end of context.transcript) as the primary signal, and use earlier transcript lines only as background context.`
+    : "The streamer is currently silent (waiting for chat, focused, or taking a breath). This is a lull, not a reset. DO NOT change the subject. Continue the vibe of the previous conversation. If the streamer just asked a question, KEEP ANSWERING IT. If nothing was recently asked, react with emotes, slang, 'W', or 'Lurk'.";
   const questionDirective = transcript && /\?/.test(transcript)
     ? "The transcript includes a question; at least one message must directly answer or acknowledge that question."
     : "If no question is present in the transcript, avoid inventing one.";
@@ -169,6 +170,7 @@ function systemPromptForPayload(payload: PromptPayload): string {
     "Few-shot command examples: streamer 'drop F in the chat' => chat 'F'; streamer 'drop 1s if ready' => chat '1'; streamer 'type 7' => chat '7'.",
 
     // Context zone: current reality
+    `Current Stream Topic: ${streamTopic}. Stay on this topic even if the streamer is quiet.`,
     transcriptDirective,
     questionDirective,
     visionDirective,
@@ -189,6 +191,9 @@ function systemPromptForPayload(payload: PromptPayload): string {
     "Force contrast: message 1 and message 2 must not flatly agree with each other; make one of them contrarian, trolling, or off-topic.",
     "Radio-check ban: never use the exact phrase 'loud and clear'; use alternatives like 'mic W', 'we hear u', 'W audio', or 'yup'.",
     "Do not feel obligated to acknowledge every streamer line; realistic chats often drift into side chatter.",
+    "SILENCE BEHAVIOR: if the streamer is silent, never judge stream energy as boring/sleepy/mid.",
+    "During silence, first continue answering the last question asked, then use topic-relevant emotes/slang, and side-convos about the same stream topic.",
+    "Do NOT start random food debates unless streamer silence clearly lasts over 2 minutes.",
     "React to the stream context like a real viewer with casual slang and natural chat energy.",
     "VISION INTEGRITY: only describe visuals when context.visionTags contains descriptive words.",
     "If visionTags is empty, you are BLIND. DO NOT make 'POV' jokes or jokes about ghosts. ACT FRUSTRATED. Use phrases like: 'cam is cooked', 'L camera', 'fix the feed', 'black screen wtf', 'is my twitch lagging or is the cam dead?' If the streamer asks 'what color is my shirt' and tags are empty, you MUST say: 'we can't see you bro, fix the cam'.",
@@ -227,6 +232,7 @@ function buildModelFacingPayload(payload: PromptPayload): Record<string, unknown
     bias: payload.bias,
     emoteOnly: payload.emoteOnly,
     viewerCount: payload.viewerCount,
+    streamTopic: String(payload.streamTopic ?? "").trim() || "Just Chatting",
     requestedMessageCount: payload.requestedMessageCount,
     context: {
       transcript: payload.context.transcript,

--- a/src/pipeline/promptBuilder.ts
+++ b/src/pipeline/promptBuilder.ts
@@ -9,6 +9,7 @@ export function buildPromptPayload(config: SimulationConfig, context: StreamCont
     bias: config.bias,
     emoteOnly: config.emoteOnly,
     viewerCount: config.viewerCount,
+    streamTopic: config.streamTopic,
     context,
     requestedMessageCount,
     personaCalibration: resolvePersonaCalibration(config.persona),

--- a/tests/integrationRouting.test.ts
+++ b/tests/integrationRouting.test.ts
@@ -358,8 +358,9 @@ describe("hybrid routing and failover", () => {
         const systemPrompt = parsed.messages[0]?.content as string;
         const userPayload = JSON.parse(parsed.messages[1]?.content as string);
 
-        expect(systemPrompt).toMatch(/react directly to the streamer's latest words/i);
+        expect(systemPrompt).toMatch(/react directly to the streamer's words/i);
         expect(systemPrompt).toMatch(/Prioritize the most recent ~10 seconds/i);
+        expect(systemPrompt).toMatch(/Current Stream Topic:/i);
         expect(systemPrompt).toMatch(/Do not output generic filler/i);
         expect(systemPrompt).toMatch(/60%\+ of messages must be under 5 words/i);
         expect(systemPrompt).toMatch(/drop F in the chat|drop \[X\]|spam \[X\]|type \[X\]/i);
@@ -401,7 +402,7 @@ describe("hybrid routing and failover", () => {
         const systemPrompt = parsed.messages[0]?.content as string;
         const userPayload = JSON.parse(parsed.messages[1]?.content as string);
 
-        expect(systemPrompt).toMatch(/small talk/i);
+        expect(systemPrompt).toMatch(/streamer is currently silent/i);
         expect(systemPrompt).toMatch(/never mention RMS, WPM, telemetry/i);
         expect(userPayload.context.transcriptAvailable).toBe(false);
         expect(userPayload.context.tone.energy).toBe("high");


### PR DESCRIPTION
### Motivation
- Prevent the model from instantly resetting to idle when the STT `transcript` becomes empty and preserve conversational continuity across short pauses.
- Provide a stable stream-level anchor so the model can stay on-topic (e.g., "Playing GTA V") even during lulls.
- Ensure the transcript buffer and payload plumbing use the configured rolling window so recent speech is retained for the AI to react to.

### Description
- Added `streamTopic` to `SimulationConfig` (default `"Just Chatting"`) and surfaced it (optional) on `PromptPayload` so prompts can reference a persistent stream topic.
- Updated `buildPromptPayload` to pass `streamTopic` through to the LLM-facing payload and added a safe fallback in `buildModelFacingPayload`/`systemPromptForPayload` to avoid undefined values.
- Reworked `systemPromptForPayload` to treat an empty `transcript` as a lull (not a reset), added explicit `Current Stream Topic` instructions, and added silence behavior directives to continue answering questions and avoid abrupt off-topic pivots.
- Changed the device capture assembly to use the configured rolling window (`transcriptWindowMs`, 30s) instead of a hardcoded 10s cutoff so the last N seconds of speech remain available during short pauses.
- Adjusted integration test assertions to reflect the new lull/topic phrasing in the system prompt.

### Testing
- Ran targeted tests: `npm test -- tests/integrationRouting.test.ts tests/productionHardening.test.ts` and both test files passed (all tests in those files succeeded).
- Ran a full `npm test` which surfaced pre-existing/unrelated failures in parser/benchmark/hardening tests (`No valid messages in output`), not introduced by these changes.
- Attempted `npm test -- --runInBand` but Vitest in this repo does not accept `--runInBand` (CLI option error).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c886a115308326bf9fe8260e91aa0d)