### PR TITLE
Unfiltered Realism 2.0: metadata-driven audience modes + anti-echo loop guard

### DIFF
--- a/src/capture/deviceCapturePipeline.ts
+++ b/src/capture/deviceCapturePipeline.ts
@@ -67,6 +67,7 @@ export class DeviceCapturePipeline {
       transcript,
       tone,
       visionTags,
+      recentChatHistory: [],
       timestamp: new Date(now).toISOString()
     };
   }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -79,6 +79,7 @@ export interface StreamContext {
   transcript: string;
   tone: ToneSnapshot;
   visionTags: string[];
+  recentChatHistory: string[];
   timestamp: string;
 }
 
@@ -89,6 +90,8 @@ export interface PromptPayload {
   viewerCount: number;
   streamTopic?: string;
   context: StreamContext;
+  situationalTags: string[];
+  behavioralModes: string[];
   requestedMessageCount: number;
   personaCalibration: PersonaCalibration;
   providerConditioning: ProviderConditioning;

--- a/src/llm/mockAudienceGenerator.ts
+++ b/src/llm/mockAudienceGenerator.ts
@@ -47,7 +47,7 @@ function realisticDonation(
   conditioning: ProviderConditioning,
   context?: StreamContext
 ): { donationCents: number | null; ttsText: string | null } {
-  const safeContext = context ?? { transcript: "", tone, visionTags: [], timestamp: new Date().toISOString() };
+  const safeContext = context ?? { transcript: "", tone, visionTags: [], recentChatHistory: [], timestamp: new Date().toISOString() };
   const features = realismModel.extract(safeContext, config.persona);
   const engagement = engagementFromSignals(config, safeContext, conditioning);
   const effectiveRate = Math.min(0.85, config.donationFrequency * engagement * (0.42 + features.donationPropensity) * (0.7 + conditioning.expressiveness * 0.4));
@@ -74,7 +74,7 @@ export function generateAudienceBatch(config: SimulationConfig, tone: ToneSnapsh
     const energetic = tone.volumeRms > 0.45 || tone.paceWpm > 160;
     const text = energetic ? `${pick(pool)} !!!` : pick(pool);
 
-    const safeContext = context ?? { transcript: "", tone, visionTags: [], timestamp: new Date().toISOString() };
+    const safeContext = context ?? { transcript: "", tone, visionTags: [], recentChatHistory: [], timestamp: new Date().toISOString() };
     const features = realismModel.extract(safeContext, config.persona);
     const message: ChatMessage = {
       id: `${Date.now()}-${idx}-${Math.random().toString(16).slice(2)}`,

--- a/src/llm/realInferenceProvider.ts
+++ b/src/llm/realInferenceProvider.ts
@@ -160,6 +160,8 @@ function systemPromptForPayload(payload: PromptPayload): string {
   const visionDirective = payload.context.visionTags.length
     ? `Vision state: context.visionTags is populated (${payload.context.visionTags.map((tag) => `"${tag}"`).join(", ")}). Reference concrete tag details directly and do not invent unseen attributes.`
     : "Vision state: context.visionTags is empty, so you are BLIND right now. Do not invent visuals; if asked visual questions, clearly say the cam/feed is not visible.";
+  const situationalTags = payload.situationalTags.length ? payload.situationalTags.join(", ") : "none";
+  const behavioralModes = payload.behavioralModes.length ? payload.behavioralModes.join(", ") : "default";
 
   return [
     // Primacy zone: engine rules
@@ -174,6 +176,10 @@ function systemPromptForPayload(payload: PromptPayload): string {
     transcriptDirective,
     questionDirective,
     visionDirective,
+    `Situational tags detected by orchestrator metadata: ${situationalTags}`,
+    `Behavioral modes selected by orchestrator: ${behavioralModes}`,
+    "Mode map: baddie/curvy/model=>thirst ('gyatt','whats the @?','respectfully 😳'); expensive_item/flex=>flex mode ('W flex','bro is rich','loaner car lol'); player_death=>respect mode ('F','L timing','trash aim'); funny/laughing=>laughter mode (mostly emotes like '😭','💀','LUL','KEKW'); disrespect/sassy=>drama mode ('O MA','oop','TEA','GOTTEM'); sarcastic=>cap mode ('cap','biggest lie ever','sure buddy')",
+    "Do not wait for the streamer to explicitly ask chat for permission; trigger hivemind reactions when metadata tags are present",
     "Treat context.transcript as more important than persona flavor text when they conflict.",
     "You are simulating a live audience reacting to the streamer in real time (not a generic standalone chat).",
     "ROLE: you are the audience. The transcript is what you heard from the streamer, not what you should say.",
@@ -183,6 +189,7 @@ function systemPromptForPayload(payload: PromptPayload): string {
     "CRITICAL: never mirror the streamer's exact question text back to chat. If streamer asks 'can you hear me?', answer it as audience (example: 'yep loud and clear').",
     "SKIP confirmation framing: do not begin by repeating topic as a question such as 'pizza?? W' or '[topic]??'. Jump straight to reaction or joke.",
     "Do not quote the streamer's exact wording unless you are intentionally making a joke/meme about it.",
+    "If transcript overlaps context.recentChatHistory heavily, treat it as the streamer reading chat; do not react to the quoted words themselves and instead react to the streamer's attitude toward chat",
     "Hard anti-echo constraint: do not reuse distinctive nouns/adjectives from the streamer's latest sentence; react with fresh wording instead.",
     "Example anti-echo: if streamer says they wear a purple sombrero, react with paraphrase like 'bro what is on your head 💀' instead of repeating those exact words.",
     "Do not simply repeat or lightly rephrase the streamer's words back to them.",
@@ -206,6 +213,8 @@ function systemPromptForPayload(payload: PromptPayload): string {
 
     // Recency zone: polish + syntax
     "Style lock: no em-dash, no ellipses, no final period, minimal capitalization, fast phone-typed fragments.",
+    "Roleplay license for realism: mild profanity is allowed when it fits chat energy (ass, shit, fucked, hell nah)",
+    "When vibe is critical, prefer raw wording like 'dogshit', 'ass', 'actual garbage' over sanitized filler",
     "Use rapid-fire Twitch-style pacing: 60%+ of messages must be under 5 words.",
     "Keep most messages short fragments, meme slang, or reactions like 'W', 'L', 'LMAO', 'ratio', 'wait what?', 'cap', 'trippin', 'idk', 'cooked', 'bro what', 'we are so back', 'yooo'.",
     `Emotes rule: emotes array may contain only unicode emoji or one of [${ALLOWED_TEXT_EMOTES.join(", ")}]. Never invent emote names.`,
@@ -242,8 +251,11 @@ function buildModelFacingPayload(payload: PromptPayload): Record<string, unknown
         pace: describePace(payload.context.tone.paceWpm)
       },
       visionTags: payload.context.visionTags,
+      recentChatHistory: payload.context.recentChatHistory,
       timestamp: payload.context.timestamp
     },
+    situationalTags: payload.situationalTags,
+    behavioralModes: payload.behavioralModes,
     personaCalibration: payload.personaCalibration,
     providerConditioning: payload.providerConditioning
   };

--- a/src/pipeline/contextAssembler.ts
+++ b/src/pipeline/contextAssembler.ts
@@ -52,6 +52,7 @@ export class ContextAssembler {
       transcript,
       tone: calibrateToneSnapshot(toneFromTranscript(transcript)),
       visionTags: this.lastVisionTags,
+      recentChatHistory: [],
       timestamp: new Date().toISOString()
     };
   }

--- a/src/pipeline/promptBuilder.ts
+++ b/src/pipeline/promptBuilder.ts
@@ -1,8 +1,33 @@
 import { PromptPayload, SimulationConfig, StreamContext } from "../core/types.js";
 import { providerConditioningForMode, resolvePersonaCalibration } from "../llm/realismSignals.js";
 
+function detectSituationalTags(context: StreamContext): string[] {
+  const tags = new Set<string>(context.visionTags.map((tag) => tag.trim().toLowerCase()).filter(Boolean));
+  const transcript = context.transcript.toLowerCase();
+  if (/\b(lmao|lmfao|haha|😭|💀|funny)\b/.test(transcript)) tags.add("funny");
+  if (/\b(laugh|laughing)\b/.test(transcript)) tags.add("laughing");
+  if (/\b(sarcasm|sarcastic|yeah right|sure buddy)\b/.test(transcript)) tags.add("sarcastic");
+  if (/\b(disrespect|sassy|outta pocket|wild)\b/.test(transcript)) tags.add("disrespect");
+  if (/\b(i died|you died|player died|death|respawn)\b/.test(transcript)) tags.add("player_death");
+  return Array.from(tags);
+}
+
+function mapBehavioralModes(situationalTags: string[]): string[] {
+  const modes = new Set<string>();
+  if (situationalTags.some((tag) => ["baddie", "curvy", "model"].includes(tag))) modes.add("thirst");
+  if (situationalTags.some((tag) => ["expensive_item", "flex"].includes(tag))) modes.add("flex");
+  if (situationalTags.includes("player_death")) modes.add("respect");
+  if (situationalTags.some((tag) => ["funny", "laughing"].includes(tag))) modes.add("laughter");
+  if (situationalTags.some((tag) => ["disrespect", "sassy"].includes(tag))) modes.add("drama");
+  if (situationalTags.includes("sarcastic")) modes.add("cap");
+  if (modes.size === 0) modes.add("default");
+  return Array.from(modes);
+}
+
 export function buildPromptPayload(config: SimulationConfig, context: StreamContext): PromptPayload {
   const requestedMessageCount = Math.max(1, Math.min(10, Math.floor(Math.sqrt(config.viewerCount) / 18) + 1));
+  const situationalTags = detectSituationalTags(context);
+  const behavioralModes = mapBehavioralModes(situationalTags);
 
   return {
     persona: config.persona,
@@ -11,6 +36,8 @@ export function buildPromptPayload(config: SimulationConfig, context: StreamCont
     viewerCount: config.viewerCount,
     streamTopic: config.streamTopic,
     context,
+    situationalTags,
+    behavioralModes,
     requestedMessageCount,
     personaCalibration: resolvePersonaCalibration(config.persona),
     providerConditioning: providerConditioningForMode(config.inferenceMode)

--- a/src/services/simulationOrchestrator.ts
+++ b/src/services/simulationOrchestrator.ts
@@ -23,6 +23,7 @@ export class SimulationOrchestrator {
   private readonly sidecar = new SidecarManager();
   private readonly mockProvider = new MockInferenceProvider();
   private readonly identityManager = new IdentityManager();
+  private recentChatHistory: string[] = [];
   private aiStatus: {
     state: "idle" | "running" | "degraded" | "error";
     providerHealth: "unknown" | "ok" | "degraded";
@@ -172,6 +173,32 @@ export class SimulationOrchestrator {
     };
   }
 
+  private tokenizeForOverlap(text: string): Set<string> {
+    return new Set(
+      text
+        .toLowerCase()
+        .replace(/[^a-z0-9\s']/g, " ")
+        .split(/\s+/)
+        .map((token) => token.trim())
+        .filter((token) => token.length >= 4)
+    );
+  }
+
+  private isReadingChat(transcript: string, recentChatHistory: string[]): boolean {
+    if (!transcript.trim() || recentChatHistory.length === 0) return false;
+    const transcriptTokens = this.tokenizeForOverlap(transcript);
+    if (!transcriptTokens.size) return false;
+    const historyTokens = this.tokenizeForOverlap(recentChatHistory.join(" "));
+    if (!historyTokens.size) return false;
+    const overlapCount = Array.from(transcriptTokens).filter((token) => historyTokens.has(token)).length;
+    return overlapCount / transcriptTokens.size >= 0.45;
+  }
+
+  private rewriteForReadingChat(messages: ChatMessage[]): ChatMessage[] {
+    const reactions = ["l chatter", "ratio that chatter", "he reading us again 💀", "chat got him pressed", "stop farming chat lines"];
+    return messages.map((message, index) => ({ ...message, text: reactions[index % reactions.length] }));
+  }
+
   private applyAntiEchoConstraint(messages: ChatMessage[], transcript: string): ChatMessage[] {
     const anchors = this.transcriptAnchorTerms(transcript);
     if (!anchors.length) return messages;
@@ -188,7 +215,7 @@ export class SimulationOrchestrator {
     return [this.antiEchoFallback(seed?.id ?? `${Date.now()}-anti-echo`, seed?.createdAt ?? new Date().toISOString())];
   }
 
-  private enforceDiversityRules(messages: ChatMessage[]): ChatMessage[] {
+  private enforceDiversityRules(messages: ChatMessage[], behavioralModes: string[]): ChatMessage[] {
     const slangCooldownWords = ["lowkey", "bet", "cooked", "fr"];
     const slangAlternatives: Record<string, string[]> = {
       lowkey: ["ngl", "tbh", "honestly"],
@@ -215,6 +242,12 @@ export class SimulationOrchestrator {
     });
 
     if (remapped.length < 2) return remapped;
+
+    if (behavioralModes.includes("thirst")) {
+      remapped[0] = { ...remapped[0], text: "gyatt respectfully 😳" };
+      remapped[1] = { ...remapped[1], text: "simps in chat stand up" };
+      return remapped;
+    }
 
     const supportiveSignal = /\b(yes|yup|we hear u|w audio|mic w|facts|same|true|good)\b/i;
     if (supportiveSignal.test(remapped[0].text) && supportiveSignal.test(remapped[1].text)) {
@@ -290,7 +323,11 @@ export class SimulationOrchestrator {
       }
 
       const captureStarted = Date.now();
-      const context = await captureProvider.getContext(config);
+      const capturedContext = await captureProvider.getContext(config);
+      const context = {
+        ...capturedContext,
+        recentChatHistory: this.recentChatHistory.slice(0, 20)
+      };
       const captureLatencyMs = Date.now() - captureStarted;
 
       timing = this.spooler.nextDelayMs(config, context.tone);
@@ -368,10 +405,13 @@ export class SimulationOrchestrator {
         }
         const inferenceLatencyMs = Date.now() - inferenceStarted;
 
-        const deEchoedMessages = this.applyAntiEchoConstraint(messages, context.transcript);
-        const diverseMessages = this.enforceDiversityRules(deEchoedMessages);
+        const deEchoedMessages = this.isReadingChat(context.transcript, context.recentChatHistory)
+          ? this.rewriteForReadingChat(messages)
+          : this.applyAntiEchoConstraint(messages, context.transcript);
+        const diverseMessages = this.enforceDiversityRules(deEchoedMessages, payload.behavioralModes);
         const safety = applySafetyPolicy(diverseMessages, config);
         const safeMessages = safety.safeMessages;
+        this.recentChatHistory = [...safeMessages.map((message) => message.text), ...this.recentChatHistory].slice(0, 40);
 
         safeMessages.forEach((msg) => {
           if (config.ttsEnabled && config.ttsMode !== "off" && msg.ttsText) {

--- a/tests/antiEcho.test.ts
+++ b/tests/antiEcho.test.ts
@@ -97,8 +97,55 @@ describe("anti-echo constraint", () => {
       }
     ];
 
-    const diverse = (orchestrator as any).enforceDiversityRules(input);
+    const diverse = (orchestrator as any).enforceDiversityRules(input, ["default"]);
     expect(diverse[1].text).not.toBe("yes w audio fr");
     expect(diverse[3].text.toLowerCase()).not.toContain("lowkey");
+  });
+
+  it("detects streamer reading chat and pivots to chatter-response messages", () => {
+    const orchestrator = makeOrchestrator();
+    const input: ChatMessage[] = [
+      {
+        id: "1",
+        username: "user1",
+        text: "any reaction",
+        emotes: [],
+        donationCents: null,
+        ttsText: null,
+        createdAt: new Date().toISOString()
+      }
+    ];
+
+    const rewritten = (orchestrator as any).isReadingChat("bro that take is wild", ["bro that take is wild", "chat got him pressed"]);
+    expect(rewritten).toBe(true);
+    const reacted = (orchestrator as any).rewriteForReadingChat(input);
+    expect(reacted[0].text).toContain("chatter");
+  });
+
+  it("forces simp vs anti-simp contrast when thirst mode is active", () => {
+    const orchestrator = makeOrchestrator();
+    const input: ChatMessage[] = [
+      {
+        id: "1",
+        username: "user1",
+        text: "w",
+        emotes: [],
+        donationCents: null,
+        ttsText: null,
+        createdAt: new Date().toISOString()
+      },
+      {
+        id: "2",
+        username: "user2",
+        text: "w",
+        emotes: [],
+        donationCents: null,
+        ttsText: null,
+        createdAt: new Date().toISOString()
+      }
+    ];
+    const diverse = (orchestrator as any).enforceDiversityRules(input, ["thirst"]);
+    expect(diverse[0].text).toContain("gyatt");
+    expect(diverse[1].text).toContain("simps");
   });
 });

--- a/tests/hardeningFlows.test.ts
+++ b/tests/hardeningFlows.test.ts
@@ -80,12 +80,12 @@ describe("sidecar lifecycle orchestration", () => {
 
 describe("malformed json fallback + stt pause", () => {
   it("parses valid JSON object even when prefixed/suffixed with junk", () => {
-    const parsed = parseInferenceOutput(`junk before {"messages":[{"username":"u","text":"hi","emotes":[]}]} junk after`);
+    const parsed = parseInferenceOutput(`junk before {"messages":[{"username":"u","text":"hi","emotes":[],"donationCents":null,"ttsText":null}]} junk after`);
     expect(parsed).toHaveLength(1);
   });
 
   it("preserves source tags from inference payload", () => {
-    const parsed = parseInferenceOutput('{"messages":[{"username":"u","text":"hi","emotes":[],"source":"fallback-mock"}]}');
+    const parsed = parseInferenceOutput('{"messages":[{"username":"u","text":"hi","emotes":[],"donationCents":null,"ttsText":null,"source":"fallback-mock"}]}');
     expect(parsed[0]?.source).toBe("fallback-mock");
   });
 

--- a/tests/integrationRouting.test.ts
+++ b/tests/integrationRouting.test.ts
@@ -49,7 +49,16 @@ describe("hybrid routing and failover", () => {
     const provider = new HybridInferenceProvider("ollama");
     const config = { ...defaultConfig, provider: { ...defaultConfig.provider, localEndpoint: server.url, localModel: "local-model" } };
     const output = await provider.generate(
-      { persona: "supportive", bias: "agree", emoteOnly: false, viewerCount: 10, requestedMessageCount: 1, context: { transcript: "hi", tone: { volumeRms: 0.4, paceWpm: 120 }, visionTags: [], timestamp: new Date().toISOString() } },
+      {
+        persona: "supportive",
+        bias: "agree",
+        emoteOnly: false,
+        viewerCount: 10,
+        requestedMessageCount: 1,
+        situationalTags: [],
+        behavioralModes: ["default"],
+        context: { transcript: "hi", tone: { volumeRms: 0.4, paceWpm: 120 }, visionTags: [], recentChatHistory: [], timestamp: new Date().toISOString() }
+      },
       config
     );
 
@@ -76,7 +85,16 @@ describe("hybrid routing and failover", () => {
     };
 
     const output = await provider.generate(
-      { persona: "supportive", bias: "agree", emoteOnly: false, viewerCount: 10, requestedMessageCount: 1, context: { transcript: "hi", tone: { volumeRms: 0.4, paceWpm: 120 }, visionTags: [], timestamp: new Date().toISOString() } },
+      {
+        persona: "supportive",
+        bias: "agree",
+        emoteOnly: false,
+        viewerCount: 10,
+        requestedMessageCount: 1,
+        situationalTags: [],
+        behavioralModes: ["default"],
+        context: { transcript: "hi", tone: { volumeRms: 0.4, paceWpm: 120 }, visionTags: [], recentChatHistory: [], timestamp: new Date().toISOString() }
+      },
       config
     );
 
@@ -110,7 +128,16 @@ describe("hybrid routing and failover", () => {
     const provider = new HybridInferenceProvider("lmstudio");
     const config = { ...defaultConfig, provider: { ...defaultConfig.provider, localEndpoint: server.url } };
     const output = await provider.generate(
-      { persona: "supportive", bias: "agree", emoteOnly: false, viewerCount: 10, requestedMessageCount: 1, context: { transcript: "hi", tone: { volumeRms: 0.4, paceWpm: 120 }, visionTags: [], timestamp: new Date().toISOString() } },
+      {
+        persona: "supportive",
+        bias: "agree",
+        emoteOnly: false,
+        viewerCount: 10,
+        requestedMessageCount: 1,
+        situationalTags: [],
+        behavioralModes: ["default"],
+        context: { transcript: "hi", tone: { volumeRms: 0.4, paceWpm: 120 }, visionTags: [], recentChatHistory: [], timestamp: new Date().toISOString() }
+      },
       config
     );
     expect(output).toContain("messages");
@@ -137,7 +164,9 @@ describe("hybrid routing and failover", () => {
       emoteOnly: false,
       viewerCount: 10,
       requestedMessageCount: 1,
-      context: { transcript: "switch now", tone: { volumeRms: 0.5, paceWpm: 140 }, visionTags: ["monitor"], timestamp: new Date().toISOString() }
+      situationalTags: [],
+      behavioralModes: ["default"],
+      context: { transcript: "switch now", tone: { volumeRms: 0.5, paceWpm: 140 }, visionTags: ["monitor"], recentChatHistory: [], timestamp: new Date().toISOString() }
     };
 
     await expect(provider.generate(payload, config)).rejects.toThrow(/429/);
@@ -158,7 +187,9 @@ describe("hybrid routing and failover", () => {
       emoteOnly: false,
       viewerCount: 10,
       requestedMessageCount: 1,
-      context: { transcript: "switch now", tone: { volumeRms: 0.5, paceWpm: 140 }, visionTags: ["monitor"], timestamp: new Date().toISOString() }
+      situationalTags: [],
+      behavioralModes: ["default"],
+      context: { transcript: "switch now", tone: { volumeRms: 0.5, paceWpm: 140 }, visionTags: ["monitor"], recentChatHistory: [], timestamp: new Date().toISOString() }
     };
 
     await expect(provider.generate(payload, config)).rejects.toThrow(/timeout\/network failure/i);
@@ -184,7 +215,9 @@ describe("hybrid routing and failover", () => {
       emoteOnly: false,
       viewerCount: 10,
       requestedMessageCount: 1,
-      context: { transcript: "switch now", tone: { volumeRms: 0.5, paceWpm: 140 }, visionTags: ["monitor"], timestamp: new Date().toISOString() }
+      situationalTags: [],
+      behavioralModes: ["default"],
+      context: { transcript: "switch now", tone: { volumeRms: 0.5, paceWpm: 140 }, visionTags: ["monitor"], recentChatHistory: [], timestamp: new Date().toISOString() }
     };
 
     await expect(provider.generate(payload, config)).rejects.toThrow(/503/);
@@ -221,7 +254,9 @@ describe("hybrid routing and failover", () => {
       emoteOnly: false,
       viewerCount: 10,
       requestedMessageCount: 1,
-      context: { transcript: "switch now", tone: { volumeRms: 0.5, paceWpm: 140 }, visionTags: ["monitor"], timestamp: new Date().toISOString() }
+      situationalTags: [],
+      behavioralModes: ["default"],
+      context: { transcript: "switch now", tone: { volumeRms: 0.5, paceWpm: 140 }, visionTags: ["monitor"], recentChatHistory: [], timestamp: new Date().toISOString() }
     };
 
     await expect(openAiProvider.generate(payload, config)).resolves.toContain("messages");
@@ -259,7 +294,9 @@ describe("hybrid routing and failover", () => {
       emoteOnly: false,
       viewerCount: 10,
       requestedMessageCount: 1,
-      context: { transcript: "switch now", tone: { volumeRms: 0.5, paceWpm: 140 }, visionTags: ["monitor"], timestamp: new Date().toISOString() }
+      situationalTags: [],
+      behavioralModes: ["default"],
+      context: { transcript: "switch now", tone: { volumeRms: 0.5, paceWpm: 140 }, visionTags: ["monitor"], recentChatHistory: [], timestamp: new Date().toISOString() }
     };
 
     await expect(provider.generate(payload, config)).resolves.toContain('"username":"newapi"');
@@ -294,7 +331,9 @@ describe("hybrid routing and failover", () => {
       emoteOnly: false,
       viewerCount: 10,
       requestedMessageCount: 1,
-      context: { transcript: "switch now", tone: { volumeRms: 0.5, paceWpm: 140 }, visionTags: ["monitor"], timestamp: new Date().toISOString() }
+      situationalTags: [],
+      behavioralModes: ["default"],
+      context: { transcript: "switch now", tone: { volumeRms: 0.5, paceWpm: 140 }, visionTags: ["monitor"], recentChatHistory: [], timestamp: new Date().toISOString() }
     };
 
     await expect(provider.generate(payload, config)).resolves.toContain("messages");
@@ -334,7 +373,9 @@ describe("hybrid routing and failover", () => {
       emoteOnly: false,
       viewerCount: 10,
       requestedMessageCount: 1,
-      context: { transcript: "can you hear me?", tone: { volumeRms: 0.5, paceWpm: 140 }, visionTags: ["monitor"], timestamp: new Date().toISOString() }
+      situationalTags: [],
+      behavioralModes: ["default"],
+      context: { transcript: "can you hear me?", tone: { volumeRms: 0.5, paceWpm: 140 }, visionTags: ["monitor"], recentChatHistory: [], timestamp: new Date().toISOString() }
     };
 
     await expect(provider.generate(payload, config)).resolves.toContain("messages");
@@ -379,7 +420,9 @@ describe("hybrid routing and failover", () => {
       emoteOnly: false,
       viewerCount: 10,
       requestedMessageCount: 1,
-      context: { transcript: "can you hear me?", tone: { volumeRms: 0.5, paceWpm: 140 }, visionTags: ["headset"], timestamp: new Date().toISOString() }
+      situationalTags: [],
+      behavioralModes: ["default"],
+      context: { transcript: "can you hear me?", tone: { volumeRms: 0.5, paceWpm: 140 }, visionTags: ["headset"], recentChatHistory: [], timestamp: new Date().toISOString() }
     };
 
     await expect(provider.generate(payload, config)).resolves.toContain("messages");
@@ -423,7 +466,9 @@ describe("hybrid routing and failover", () => {
       emoteOnly: false,
       viewerCount: 10,
       requestedMessageCount: 1,
-      context: { transcript: "", tone: { volumeRms: 0.8, paceWpm: 180 }, visionTags: [], timestamp: new Date().toISOString() }
+      situationalTags: [],
+      behavioralModes: ["default"],
+      context: { transcript: "", tone: { volumeRms: 0.8, paceWpm: 180 }, visionTags: [], recentChatHistory: [], timestamp: new Date().toISOString() }
     };
 
     await expect(provider.generate(payload, config)).resolves.toContain("messages");

--- a/tests/nfrBenchmarks.test.ts
+++ b/tests/nfrBenchmarks.test.ts
@@ -7,7 +7,13 @@ import { defaultConfig } from "../src/config/runtimeConfig.js";
 describe("NFR measurement pass", () => {
   it("meets parser throughput + latency threshold", () => {
     const payload = JSON.stringify({
-      messages: Array.from({ length: 20 }, (_, i) => ({ username: `u${i}`, text: `hello ${i}`, emotes: [] }))
+      messages: Array.from({ length: 20 }, (_, i) => ({
+        username: `u${i}`,
+        text: `hello ${i}`,
+        emotes: [],
+        donationCents: null,
+        ttsText: null
+      }))
     });
 
     const runs = 200;

--- a/tests/realismSignals.test.ts
+++ b/tests/realismSignals.test.ts
@@ -15,11 +15,11 @@ describe("realism signal extraction + calibration", () => {
   it("provides rolling excitement + donation propensity + persona-conditioned bias", () => {
     const model = new RealismSignalModel();
     const baseline = model.extract(
-      { transcript: "chat what should we do", tone: { volumeRms: 0.3, paceWpm: 110 }, visionTags: [], timestamp: new Date().toISOString() },
+      { transcript: "chat what should we do", tone: { volumeRms: 0.3, paceWpm: 110 }, visionTags: [], recentChatHistory: [], timestamp: new Date().toISOString() },
       "neutral"
     );
     const excited = model.extract(
-      { transcript: "CHAT LETS GO!!! clip that!!!", tone: { volumeRms: 0.8, paceWpm: 190 }, visionTags: ["keyboard", "lights"], timestamp: new Date().toISOString() },
+      { transcript: "CHAT LETS GO!!! clip that!!!", tone: { volumeRms: 0.8, paceWpm: 190 }, visionTags: ["keyboard", "lights"], recentChatHistory: [], timestamp: new Date().toISOString() },
       "supportive"
     );
 


### PR DESCRIPTION
### Motivation
- Shift audience intelligence into metadata so small models can trigger authentic, spontaneous chat behavior (thirst, drama, laughter, flex, respect, cap) without waiting for explicit streamer prompts.
- Prevent echo loops when the streamer reads chat aloud by feeding recent emitted chat back into context and detecting overlaps.
- Introduce conflict-based realism (contrasting archetypes) and permit a measured "unfiltered" voice for realism while preserving the strict JSON contract and safety pipeline.

### Description
- Extended core schema by adding `recentChatHistory` to `StreamContext` and `situationalTags` + `behavioralModes` to `PromptPayload` so the orchestrator can surface metadata into model prompts (`src/core/types.ts`).
- Implemented situational tag detection and a behavioral-mode mapper in `buildPromptPayload` that derives tags from transcript + vision and maps them to modes like `thirst`, `flex`, `respect`, `laughter`, `drama`, and `cap` (`src/pipeline/promptBuilder.ts`).
- Enhanced `SimulationOrchestrator` to maintain `recentChatHistory`, inject it into capture context, detect "reading chat" via token overlap (`isReadingChat`) and pivot to chatter-response rewrites (`rewriteForReadingChat`) to avoid quoting echoes; updated anti-echo and diversity enforcement to accept behavioral modes and force thirst-mode contrast (simp vs anti-simp) (`src/services/simulationOrchestrator.ts`).
- Extended the system prompt in the real inference provider to surface situational tags/behavioral modes, reading-chat guidance, and the targeted unfiltered style guidance while keeping the strict JSON output rules and model-facing payload shape (`src/llm/realInferenceProvider.ts`).
- Propagated `recentChatHistory` into mock and capture codepaths and updated mock audience generation to accept the new context shape (`src/capture/deviceCapturePipeline.ts`, `src/pipeline/contextAssembler.ts`, `src/llm/mockAudienceGenerator.ts`).
- Updated and added tests and fixtures to cover the new schema and behaviors, and adjusted parser test payloads to include `donationCents`/`ttsText` fields required by the parser (`tests/*`).

### Testing
- Ran the test suite with `npm test` (Vitest) and all tests passed: 76 tests, 76 passed across 17 files.
- Built the project with `npm run build` and the TypeScript build succeeded.
- Note: an initial attempt to run `npm test -- --runInBand` failed because Vitest in this repo does not accept `--runInBand` (unknown option), but the standard `npm test` execution succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8a4bd1a888326a4dc001e72aee48b)