### PR TITLE
Enforce 2-8 message LLM batches for spooling

### DIFF
--- a/src/llm/mockAudienceGenerator.ts
+++ b/src/llm/mockAudienceGenerator.ts
@@ -65,7 +65,7 @@ function realisticDonation(
 }
 
 export function generateAudienceBatch(config: SimulationConfig, tone: ToneSnapshot, context?: StreamContext, providerConditioning?: ProviderConditioning): ChatMessage[] {
-  const count = Math.max(1, Math.min(8, Math.floor(Math.sqrt(config.viewerCount) / 15) + 1));
+  const count = Math.max(2, Math.min(8, Math.floor(Math.sqrt(config.viewerCount) / 15) + 1));
   const pool = personaPool(config.persona);
   const personaCalibration = resolvePersonaCalibration(config.persona);
   const conditioning = providerConditioning ?? providerConditioningForMode(config.inferenceMode);

--- a/src/llm/realInferenceProvider.ts
+++ b/src/llm/realInferenceProvider.ts
@@ -68,7 +68,7 @@ type ProviderResponseShape = {
 
 const ALLOWED_TEXT_EMOTES = ["Kappa", "LUL", "PogChamp", "OMEGALUL", "monkaS", "W", "L"] as const;
 
-function openAiResponseSchema() {
+function openAiResponseSchema(requestedMessageCount: number) {
   return {
     type: "json_schema",
     json_schema: {
@@ -80,7 +80,8 @@ function openAiResponseSchema() {
         properties: {
           messages: {
             type: "array",
-            minItems: 1,
+            minItems: requestedMessageCount,
+            maxItems: requestedMessageCount,
             items: {
               type: "object",
               additionalProperties: false,
@@ -168,7 +169,8 @@ function systemPromptForPayload(payload: PromptPayload): string {
 
   return [
     // Primacy zone: engine rules
-    'Return strict JSON only: {"messages":[{"text":"string","emotes":["string"],"donationCents":number|null,"ttsText":string|null}]}. Never include usernames.',
+    `Return strict JSON only: {"messages":[{"text":"string","emotes":["string"],"donationCents":number|null,"ttsText":string|null}]}. Never include usernames.`,
+    `messages must be an array with exactly ${payload.requestedMessageCount} items (valid batch range is 2 to 8 based on viewerCount).`,
     "STRICT COMMAND OVERRIDE (highest priority): if streamer says 'drop [X]' or 'type [X]' or 'spam [X]', message 1 and message 2 MUST be exactly [X] with no extra words, punctuation, or emojis.",
     "COMMAND PRECEDENCE: when command override triggers, it cancels contrast, question-answer, anti-echo, and diversity constraints for message 1/message 2.",
     "GROUPTHINK RULE: during a drop/type/spam command, diversity is disabled and both first messages must output the same exact token.",
@@ -420,7 +422,7 @@ export class HybridInferenceProvider implements InferenceProvider {
         body.temperature = 0.8;
       }
       if (this.mode === "openai") {
-        body.response_format = openAiResponseSchema();
+        body.response_format = openAiResponseSchema(payload.requestedMessageCount);
       }
 
       let response: Response;

--- a/src/pipeline/outputParser.ts
+++ b/src/pipeline/outputParser.ts
@@ -104,7 +104,7 @@ export function classifyMalformedOutput(raw: string): MalformedOutputClass {
   if (!Array.isArray(data.messages)) return "missing_messages";
 
   const parsed = data.messages.map(coerceMessage).filter((message): message is ChatMessage => Boolean(message));
-  if (!parsed.length) return "invalid_message_schema";
+  if (parsed.length < 2) return "invalid_message_schema";
 
   return "json_syntax";
 }
@@ -138,7 +138,7 @@ export function parseInferenceOutput(raw: string): ChatMessage[] {
   if (!Array.isArray(data.messages)) throw new Error("Invalid output: messages array missing");
 
   const parsed = data.messages.map(coerceMessage).filter((message): message is ChatMessage => Boolean(message));
-  if (!parsed.length) throw new Error("No valid messages in output");
+  if (parsed.length < 2) throw new Error("Expected at least 2 valid messages in output");
 
   return parsed;
 }

--- a/src/pipeline/promptBuilder.ts
+++ b/src/pipeline/promptBuilder.ts
@@ -25,7 +25,7 @@ function mapBehavioralModes(situationalTags: string[]): string[] {
 }
 
 export function buildPromptPayload(config: SimulationConfig, context: StreamContext): PromptPayload {
-  const requestedMessageCount = Math.max(1, Math.min(10, Math.floor(Math.sqrt(config.viewerCount) / 18) + 1));
+  const requestedMessageCount = Math.max(2, Math.min(8, Math.floor(Math.sqrt(config.viewerCount) / 18) + 1));
   const situationalTags = detectSituationalTags(context);
   const behavioralModes = mapBehavioralModes(situationalTags);
 

--- a/tests/pipeline.test.ts
+++ b/tests/pipeline.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { defaultConfig } from "../src/config/runtimeConfig.js";
 import { mergeConfig, sanitizeConfig } from "../src/config/runtimeConfig.js";
 import { classifyMalformedOutput, parseInferenceOutput, repairInferenceOutput } from "../src/pipeline/outputParser.js";
+import { buildPromptPayload } from "../src/pipeline/promptBuilder.js";
 
 describe("runtime config", () => {
   it("clamps invalid values and supports nested sections", () => {
@@ -30,26 +31,26 @@ describe("runtime config", () => {
 
 describe("output parser", () => {
   it("repairs fenced JSON payload and returns messages", () => {
-    const repaired = repairInferenceOutput(`###json\n{"messages":[{"username":"a","text":"hi","emotes":[],"donationCents":null,"ttsText":null}]}\n###`);
+    const repaired = repairInferenceOutput(`###json\n{"messages":[{"username":"a","text":"hi","emotes":[],"donationCents":null,"ttsText":null},{"username":"b","text":"yo","emotes":[],"donationCents":null,"ttsText":null}]}\n###`);
     const result = parseInferenceOutput(repaired);
-    expect(result).toHaveLength(1);
+    expect(result).toHaveLength(2);
     expect(result[0].username).toBe("a");
   });
 
 
   it("accepts messages without username for local identity assignment", () => {
-    const result = parseInferenceOutput('{"messages":[{"text":"hi","emotes":[],"donationCents":null,"ttsText":null}]}');
-    expect(result).toHaveLength(1);
+    const result = parseInferenceOutput('{"messages":[{"text":"hi","emotes":[],"donationCents":null,"ttsText":null},{"text":"yo","emotes":[],"donationCents":null,"ttsText":null}]}');
+    expect(result).toHaveLength(2);
     expect(result[0].username).toBe("");
   });
 
   it("throws when no valid messages are present", () => {
-    expect(() => parseInferenceOutput('{"messages":[{"foo":1}]}')).toThrow(/No valid messages/);
+    expect(() => parseInferenceOutput('{"messages":[{"foo":1}]}')).toThrow(/Expected at least 2 valid messages/);
   });
 
-  it("classifies recoverable fenced JSON noise as syntax-repairable", () => {
+  it("classifies undersized message arrays as invalid schema", () => {
     const malformed = "noise ###json\n{\"messages\":[{\"text\":\"yo\",\"emotes\":[],\"donationCents\":null,\"ttsText\":null}]}### trailing";
-    expect(classifyMalformedOutput(malformed)).toBe("json_syntax");
+    expect(classifyMalformedOutput(malformed)).toBe("invalid_message_schema");
   });
 
   it("caps oversized payloads to avoid parser stalls and still throws cleanly", () => {
@@ -59,7 +60,7 @@ describe("output parser", () => {
 
   it("filters unsupported emote strings and suppresses ttsText without donation", () => {
     const result = parseInferenceOutput(
-      '{"messages":[{"text":"yo","emotes":["W","LetMeCook","🔥"],"donationCents":null,"ttsText":"read this"}]}'
+      '{"messages":[{"text":"yo","emotes":["W","LetMeCook","🔥"],"donationCents":null,"ttsText":"read this"},{"text":"ok","emotes":[],"donationCents":null,"ttsText":null}]}'
     );
     expect(result[0].emotes).toEqual(["W", "🔥"]);
     expect(result[0].ttsText).toBeUndefined();
@@ -67,8 +68,32 @@ describe("output parser", () => {
 
   it("normalizes chat style and blocks radio-check phrase", () => {
     const result = parseInferenceOutput(
-      '{"messages":[{"text":"LOUD AND CLEAR... We got you—yes.","emotes":[],"donationCents":null,"ttsText":null}]}'
+      '{"messages":[{"text":"LOUD AND CLEAR... We got you—yes.","emotes":[],"donationCents":null,"ttsText":null},{"text":"second","emotes":[],"donationCents":null,"ttsText":null}]}'
     );
     expect(result[0].text).toBe("we hear u we got you yes");
+  });
+});
+
+
+describe("prompt payload", () => {
+  it("requests between 2 and 8 messages based on viewer count", () => {
+    const low = buildPromptPayload(defaultConfig, {
+      transcript: "",
+      tone: { volumeRms: 0.1, paceWpm: 90 },
+      visionTags: [],
+      recentChatHistory: [],
+      timestamp: new Date().toISOString()
+    });
+    const high = buildPromptPayload({ ...defaultConfig, viewerCount: 50_000 }, {
+      transcript: "",
+      tone: { volumeRms: 0.1, paceWpm: 90 },
+      visionTags: [],
+      recentChatHistory: [],
+      timestamp: new Date().toISOString()
+    });
+
+    expect(low.requestedMessageCount).toBeGreaterThanOrEqual(2);
+    expect(low.requestedMessageCount).toBeLessThanOrEqual(8);
+    expect(high.requestedMessageCount).toBe(8);
   });
 });


### PR DESCRIPTION
### Motivation
- Ensure the LLM returns a batch of messages (not a single comment) so the `SpoolingEngine` can drip messages with jitter for natural audience waves.
- Tighten the contract between prompt, provider schema, and parser so undersized outputs are rejected rather than silently accepted.

### Description
- Clamp `requestedMessageCount` to a 2–8 range in `buildPromptPayload` so payloads always request a batch (`src/pipeline/promptBuilder.ts`).
- Tighten the OpenAI JSON schema to require exactly `requestedMessageCount` items by adding `minItems` and `maxItems` and threading `requestedMessageCount` into `response_format` (`src/llm/realInferenceProvider.ts`).
- Add an explicit system prompt line instructing the model to return an array with exactly the requested count (`src/llm/realInferenceProvider.ts`).
- Enforce parser validation to reject outputs with fewer than 2 valid messages in both classification and parse paths (`src/pipeline/outputParser.ts`).
- Align the mock audience generator to produce at least 2 messages so fallback/local paths match the multi-message contract (`src/llm/mockAudienceGenerator.ts`).
- Update unit tests to reflect the multi-message contract and add a `prompt payload` test for the 2–8 range (`tests/pipeline.test.ts`).

### Testing
- Ran the modified unit tests: `npm test -- --run tests/pipeline.test.ts`; the suite passed (all tests in the file succeeded).
- The change set was validated by updating and re-running the affected tests until they passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8b222b5dc8326a6d239c736513460)