### PR TITLE
Upgrade Deepgram SDK to v5, add Nova-3/Aura-2 support and harden DEEPGRAM_API_KEY persistence

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "streamsim",
       "version": "0.1.0",
       "dependencies": {
-        "@deepgram/sdk": "^3.9.0",
+        "@deepgram/sdk": "^5.0.0",
         "express": "^4.19.2"
       },
       "devDependencies": {
@@ -19,49 +19,17 @@
         "vitest": "^2.1.4"
       }
     },
-    "node_modules/@deepgram/captions": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@deepgram/captions/-/captions-1.2.0.tgz",
-      "integrity": "sha512-8B1C/oTxTxyHlSFubAhNRgCbQ2SQ5wwvtlByn8sDYZvdDtdn/VE2yEPZ4BvUnrKWmsbTQY6/ooLV+9Ka2qmDSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "dayjs": "^1.11.10"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@deepgram/sdk": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/@deepgram/sdk/-/sdk-3.13.0.tgz",
-      "integrity": "sha512-VFN4gbyIDl5Bj0ApERq4QJHzO2AK4YOoL5Lfoy//q9531+UIzaKCNie4NkBM2Kn/UndHH7tIR335SH14e2r+Ag==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@deepgram/sdk/-/sdk-5.0.0.tgz",
+      "integrity": "sha512-x1wMiOgDGqcLEaQpQBQLTtk5mLbXbYgcBEpp7cfJIyEtqdIGgijCZH+a/esiVp+xIcTYYroTxG47RVppZOHbWw==",
       "license": "MIT",
       "dependencies": {
-        "@deepgram/captions": "^1.1.1",
-        "@types/node": "^18.19.39",
-        "cross-fetch": "^3.1.5",
-        "deepmerge": "^4.3.1",
-        "events": "^3.3.0",
-        "ws": "^8.17.0"
+        "ws": "^8.16.0"
       },
       "engines": {
         "node": ">=18.0.0"
       }
-    },
-    "node_modules/@deepgram/sdk/node_modules/@types/node": {
-      "version": "18.19.130",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
-      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/@deepgram/sdk/node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.4",
@@ -1264,21 +1232,6 @@
       "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
       "license": "MIT"
     },
-    "node_modules/cross-fetch": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
-      "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
-      "license": "MIT",
-      "dependencies": {
-        "node-fetch": "^2.7.0"
-      }
-    },
-    "node_modules/dayjs": {
-      "version": "1.11.20",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
-      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
-      "license": "MIT"
-    },
     "node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -1296,15 +1249,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/deepmerge": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
-      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/depd": {
@@ -1457,15 +1401,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/events": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.x"
       }
     },
     "node_modules/expect-type": {
@@ -1835,26 +1770,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
       }
     },
     "node_modules/object-inspect": {
@@ -2297,12 +2212,6 @@
       "engines": {
         "node": ">=0.6"
       }
-    },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
     },
     "node_modules/tsx": {
       "version": "4.21.0",
@@ -3013,22 +2922,6 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
     },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "ci:capture-traces": "tsx scripts/capture-nfr-traces.ts"
   },
   "dependencies": {
-    "@deepgram/sdk": "^3.9.0",
+    "@deepgram/sdk": "^5.0.0",
     "express": "^4.19.2"
   },
   "devDependencies": {

--- a/src/capture/sttEngine.ts
+++ b/src/capture/sttEngine.ts
@@ -1,4 +1,5 @@
 import { Readable } from "node:stream";
+import { DeepgramClient } from "@deepgram/sdk";
 import { SecretStore } from "../security/secretStore.js";
 import { sharedDeviceCapturePipeline } from "./deviceCapturePipeline.js";
 
@@ -9,7 +10,7 @@ interface SttBackend {
 }
 
 const DEFAULT_LOCAL_STT_ENDPOINT = "http://127.0.0.1:7778/stt";
-const DEFAULT_DEEPGRAM_ENDPOINT = "https://api.deepgram.com/v1/listen?model=nova-2&language=en-US&smart_format=true&filler_words=true&punctuate=true";
+const DEFAULT_DEEPGRAM_ENDPOINT = "https://api.deepgram.com/v1/listen?model=nova-3&language=en-US&smart_format=true&filler_words=true&punctuate=true&sentiment=true&intents=true&topics=true";
 const DEFAULT_OPENAI_STT_ENDPOINT = "https://api.openai.com/v1/audio/transcriptions";
 
 class MockSttBackend implements SttBackend {
@@ -48,23 +49,32 @@ class DeepgramBackend implements SttBackend {
   public async transcribe(frame: Buffer): Promise<string> {
     const token = this.apiKey ?? this.secretStore.getDeepgramApiKey();
     if (!token) throw new Error("Deepgram API key missing.");
-    let response: Response;
+
+    const endpoint = new URL(this.endpoint);
+    const model = endpoint.searchParams.get("model") ?? "nova-3";
+    const language = endpoint.searchParams.get("language") ?? "en-US";
+
+    const client = new DeepgramClient({ apiKey: token });
+
     try {
-      response = await fetch(this.endpoint, {
-        method: "POST",
-        headers: {
-          Authorization: `Token ${token}`,
-          "Content-Type": "audio/wav"
-        },
-        body: new Uint8Array(frame),
-        signal: AbortSignal.timeout(2500)
+      const response = await client.listen.v1.media.transcribeFile(frame, {
+        model,
+        language,
+        smart_format: true,
+        filler_words: true,
+        punctuate: true,
+        sentiment: true,
+        intents: true,
+        topics: true
       });
+      const payload = response as unknown as {
+        results?: { channels?: Array<{ alternatives?: Array<{ transcript?: string }> }> };
+        result?: { results?: { channels?: Array<{ alternatives?: Array<{ transcript?: string }> }> } };
+      };
+      return payload.results?.channels?.[0]?.alternatives?.[0]?.transcript?.trim() ?? payload.result?.results?.channels?.[0]?.alternatives?.[0]?.transcript?.trim() ?? "";
     } catch (error) {
       throw new Error(`Deepgram STT request failed for ${this.endpoint}: ${(error as Error).message}`);
     }
-    if (!response.ok) throw new Error(`Deepgram STT failed (${response.status}).`);
-    const json = (await response.json()) as { transcript?: string; results?: { channels?: Array<{ alternatives?: Array<{ transcript?: string }> }> } };
-    return json.transcript?.trim() ?? json.results?.channels?.[0]?.alternatives?.[0]?.transcript?.trim() ?? "";
   }
 }
 

--- a/src/config/runtimeConfig.ts
+++ b/src/config/runtimeConfig.ts
@@ -17,7 +17,7 @@ export const defaultConfig: SimulationConfig = {
     visionEnabled: true,
     visionIntervalSec: 25,
     useRealCapture: true,
-    sttEndpoint: process.env.STREAMSIM_DEEPGRAM_ENDPOINT ?? "https://api.deepgram.com/v1/listen?model=nova-2&smart_format=true&filler_words=true&punctuate=true",
+    sttEndpoint: process.env.STREAMSIM_DEEPGRAM_ENDPOINT ?? "https://api.deepgram.com/v1/listen?model=nova-3&smart_format=true&filler_words=true&punctuate=true&sentiment=true&topics=true&intents=true",
     sttProvider: process.env.SIM_DEFAULT_STT === "deepgram_nova_2" ? "deepgram" : "local-whisper",
     visionEndpoint: "http://127.0.0.1:7778/vision-tags"
   },

--- a/src/public/app.js
+++ b/src/public/app.js
@@ -47,7 +47,7 @@ const CAMERA_FRAME_CONFIRM_TIMEOUT_MS = 3000;
 const STT_DEFAULT_ENDPOINTS = {
   "local-whisper": "http://127.0.0.1:7778/stt",
   whispercpp: "http://127.0.0.1:7778/stt",
-  deepgram: "https://api.deepgram.com/v1/listen?model=nova-2&language=en-US&smart_format=true&filler_words=true&punctuate=true",
+  deepgram: "https://api.deepgram.com/v1/listen?model=nova-3&language=en-US&smart_format=true&filler_words=true&punctuate=true&sentiment=true&topics=true&intents=true",
   "openai-whisper": "https://api.openai.com/v1/audio/transcriptions",
   "gpt-4o-mini-transcribe": "https://api.openai.com/v1/audio/transcriptions",
   mock: "http://127.0.0.1:7778/stt"
@@ -932,37 +932,33 @@ runReadinessBtn.addEventListener("click", async () => {
 });
 
 saveCloudKeyBtn.addEventListener("click", async () => {
-  await runAction({
+  const saved = await runAction({
     button: saveCloudKeyBtn,
     pendingText: "Saving cloud API key...",
     successText: "Cloud API key saved to keychain.",
     onRun: () => post("/api/secrets/cloud-key", { key: controls.cloudApiKey.value })
   });
+  if (!saved) return;
   controls.cloudApiKey.value = "";
+  await refreshStatus();
 });
 
 saveDeepgramKeyBtn.addEventListener("click", async () => {
-  await runAction({
+  const saved = await runAction({
     button: saveDeepgramKeyBtn,
     pendingText: "Saving Deepgram API key...",
     successText: "Deepgram API key saved to keychain.",
     onRun: () => post("/api/secrets/deepgram-key", { key: controls.deepgramApiKey.value })
   });
+  if (!saved) return;
   controls.deepgramApiKey.value = "";
+  await refreshStatus();
 });
 
-refreshStatusBtn.addEventListener("click", async () => {
-  const payload = await runAction({
-    button: refreshStatusBtn,
-    pendingText: "Refreshing status...",
-    successText: "Status refreshed.",
-    onRun: async () => {
-      const response = await fetch("/api/status");
-      if (!response.ok) throw new Error(`Status request failed (${response.status})`);
-      return response.json();
-    }
-  });
-  if (!payload) return;
+async function refreshStatus() {
+  const response = await fetch("/api/status");
+  if (!response.ok) throw new Error(`Status request failed (${response.status})`);
+  const payload = await response.json();
   latestStatusPayload = payload;
   renderReadiness(payload.readiness);
   renderDiagnostics(payload);
@@ -972,6 +968,16 @@ refreshStatusBtn.addEventListener("click", async () => {
   summarizeAiHealth(payload);
   summarizeTtsHealth(payload);
   summarizeSttHealth(payload);
+  return payload;
+}
+
+refreshStatusBtn.addEventListener("click", async () => {
+  await runAction({
+    button: refreshStatusBtn,
+    pendingText: "Refreshing status...",
+    successText: "Status refreshed.",
+    onRun: () => refreshStatus()
+  });
 });
 
 verifyMicBtn?.addEventListener("click", async () => {

--- a/src/security/secretStore.ts
+++ b/src/security/secretStore.ts
@@ -1,8 +1,14 @@
 import { execFileSync } from "node:child_process";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import os from "node:os";
 
 const SERVICE_NAME = "streamsim";
 const CLOUD_ACCOUNT_NAME = "cloud-api-key";
 const DEEPGRAM_ACCOUNT_NAME = "deepgram-api-key";
+const SECRET_FILE_PATH = path.join(os.homedir(), ".streamsim", "secrets.json");
+
+type SecretKeyName = "STREAMSIM_CLOUD_API_KEY" | "DEEPGRAM_API_KEY";
 
 export interface SecretStoreDiagnostics {
   keychainBacked: boolean;
@@ -127,41 +133,91 @@ function createProvider(): SecretProvider {
   return new UnsupportedProvider();
 }
 
+function readFileSecrets(): Partial<Record<SecretKeyName, string>> {
+  try {
+    const raw = readFileSync(SECRET_FILE_PATH, "utf8");
+    const parsed = JSON.parse(raw) as Partial<Record<SecretKeyName, string>>;
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function writeFileSecrets(nextValues: Partial<Record<SecretKeyName, string>>): boolean {
+  try {
+    mkdirSync(path.dirname(SECRET_FILE_PATH), { recursive: true });
+    writeFileSync(SECRET_FILE_PATH, JSON.stringify(nextValues, null, 2), { mode: 0o600 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export class SecretStore {
   private readonly provider = createProvider();
 
   public getCloudApiKey(): string {
-    const fromKeychain = this.getKeyFromKeychain(CLOUD_ACCOUNT_NAME);
-    if (fromKeychain) return fromKeychain;
-    return process.env.STREAMSIM_CLOUD_API_KEY ?? "";
+    return this.getSecretValue("STREAMSIM_CLOUD_API_KEY", CLOUD_ACCOUNT_NAME, ["STREAMSIM_CLOUD_API_KEY"]);
   }
 
   public setCloudApiKey(value: string): boolean {
-    return this.setKeyInKeychain(CLOUD_ACCOUNT_NAME, "StreamSim Cloud API Key", value);
+    return this.setSecretValue("STREAMSIM_CLOUD_API_KEY", CLOUD_ACCOUNT_NAME, "StreamSim Cloud API Key", value);
   }
 
   public getDeepgramApiKey(): string {
-    const fromKeychain = this.getKeyFromKeychain(DEEPGRAM_ACCOUNT_NAME);
-    if (fromKeychain) return fromKeychain;
-    return process.env.DEEPGRAM_API_KEY ?? process.env.STREAMSIM_DEEPGRAM_API_KEY ?? "";
+    return this.getSecretValue("DEEPGRAM_API_KEY", DEEPGRAM_ACCOUNT_NAME, ["DEEPGRAM_API_KEY", "STREAMSIM_DEEPGRAM_API_KEY"]);
   }
 
   public setDeepgramApiKey(value: string): boolean {
-    return this.setKeyInKeychain(DEEPGRAM_ACCOUNT_NAME, "StreamSim Deepgram API Key", value);
+    return this.setSecretValue("DEEPGRAM_API_KEY", DEEPGRAM_ACCOUNT_NAME, "StreamSim Deepgram API Key", value);
+  }
+
+  public hasKey(name: SecretKeyName): boolean {
+    if (name === "DEEPGRAM_API_KEY") return Boolean(this.getDeepgramApiKey());
+    return Boolean(this.getCloudApiKey());
   }
 
   public diagnostics(): SecretStoreDiagnostics {
     const availability = this.provider.isAvailable();
     const cloudKeychainValue = this.getKeyFromKeychain(CLOUD_ACCOUNT_NAME);
     const deepgramKeychainValue = this.getKeyFromKeychain(DEEPGRAM_ACCOUNT_NAME);
+    const fromFile = readFileSecrets();
     return {
       keychainBacked: Boolean(cloudKeychainValue || deepgramKeychainValue),
-      hasCloudKey: Boolean(cloudKeychainValue || process.env.STREAMSIM_CLOUD_API_KEY),
-      hasDeepgramKey: Boolean(deepgramKeychainValue || process.env.DEEPGRAM_API_KEY || process.env.STREAMSIM_DEEPGRAM_API_KEY),
-      provider: this.provider.name,
-      available: availability.ok,
+      hasCloudKey: Boolean(cloudKeychainValue || fromFile.STREAMSIM_CLOUD_API_KEY || process.env.STREAMSIM_CLOUD_API_KEY),
+      hasDeepgramKey: Boolean(deepgramKeychainValue || fromFile.DEEPGRAM_API_KEY || process.env.DEEPGRAM_API_KEY || process.env.STREAMSIM_DEEPGRAM_API_KEY),
+      provider: availability.ok ? this.provider.name : `${this.provider.name}+file-fallback`,
+      available: availability.ok || Boolean(fromFile.STREAMSIM_CLOUD_API_KEY || fromFile.DEEPGRAM_API_KEY),
       warning: availability.warning
     };
+  }
+
+  private getSecretValue(name: SecretKeyName, account: string, envFallbackNames: string[]): string {
+    const fromKeychain = this.getKeyFromKeychain(account);
+    if (fromKeychain) return fromKeychain;
+
+    const fromFile = readFileSecrets()[name];
+    if (fromFile) return fromFile;
+
+    for (const envName of envFallbackNames) {
+      const fromEnv = process.env[envName];
+      if (fromEnv) return fromEnv;
+    }
+    return "";
+  }
+
+  private setSecretValue(name: SecretKeyName, account: string, label: string, value: string): boolean {
+    const normalized = value.trim();
+    if (!normalized) return false;
+
+    const savedInKeychain = this.setKeyInKeychain(account, label, normalized);
+    if (!savedInKeychain) {
+      const existing = readFileSecrets();
+      if (!writeFileSecrets({ ...existing, [name]: normalized })) return false;
+    }
+
+    process.env[name] = normalized;
+    return true;
   }
 
   private getKeyFromKeychain(account: string): string {

--- a/src/server.ts
+++ b/src/server.ts
@@ -295,7 +295,7 @@ app.get("/api/status", (_req, res) => {
     stt: {
       configuredProvider: config.capture.sttProvider,
       engineProvider: sharedSttEngine.state().provider,
-      deepgramKeyPresent: Boolean(process.env.DEEPGRAM_API_KEY ?? process.env.STREAMSIM_DEEPGRAM_API_KEY),
+      deepgramKeyPresent: secretStore.diagnostics().hasDeepgramKey,
       cloudKeyPresent: secretStore.diagnostics().hasCloudKey,
       endpoint: config.capture.sttEndpoint,
       localConfigured: config.capture.sttProvider === "local-whisper",

--- a/src/services/readinessChecks.ts
+++ b/src/services/readinessChecks.ts
@@ -1,6 +1,10 @@
 import { SimulationConfig } from "../core/types.js";
 import { SidecarManager } from "./sidecarManager.js";
+import { SecretStore } from "../security/secretStore.js";
 
+
+
+const secretStore = new SecretStore();
 export interface ReadinessCheck {
   id: "device" | "network" | "sidecar" | "credentials";
   ok: boolean;
@@ -83,13 +87,16 @@ function checkCredentials(config: SimulationConfig, credentials: { hasCloudKey: 
       message: "Cloud mode selected without a stored API key. Save a cloud key or switch to local mode."
     };
   }
-  if ((config.capture.sttProvider === "deepgram" || deepgramTts) && !credentials.hasDeepgramKey) {
-    return {
-      id: "credentials",
-      ok: false,
-      severity: "blocking",
-      message: "Deepgram mode selected without a stored Deepgram key. Save DEEPGRAM_API_KEY in Secrets."
-    };
+  if (config.capture.sttProvider === "deepgram" || deepgramTts) {
+    const hasKey = credentials.hasDeepgramKey || secretStore.hasKey("DEEPGRAM_API_KEY");
+    if (!hasKey) {
+      return {
+        id: "credentials",
+        ok: false,
+        severity: "blocking",
+        message: "Missing Deepgram API Key"
+      };
+    }
   }
 
   return {

--- a/src/services/stt/deepgramProvider.ts
+++ b/src/services/stt/deepgramProvider.ts
@@ -1,3 +1,5 @@
+import { DeepgramClient } from "@deepgram/sdk";
+
 export interface DeepgramSttOptions {
   apiKey: string;
   model?: string;
@@ -7,26 +9,22 @@ export interface DeepgramSttOptions {
   intents?: boolean;
   topics?: boolean;
   sentiment?: boolean;
-  endpoint?: string;
 }
 
-export class DeepgramNova2Provider {
+export class DeepgramNova3Provider {
   constructor(private readonly options: DeepgramSttOptions) {}
 
-  public buildRealtimeUrl(): string {
-    const endpoint = this.options.endpoint ?? "wss://api.deepgram.com/v1/listen";
-    const url = new URL(endpoint);
-    url.searchParams.set("model", this.options.model ?? "nova-2");
-    url.searchParams.set("language", this.options.language ?? "en-US");
-    url.searchParams.set("smart_format", String(this.options.smartFormat ?? true));
-    url.searchParams.set("filler_words", String(this.options.fillerWords ?? true));
-    url.searchParams.set("sentiment", String(this.options.sentiment ?? false));
-    url.searchParams.set("intents", String(this.options.intents ?? false));
-    url.searchParams.set("topics", String(this.options.topics ?? false));
-    return url.toString();
-  }
-
-  public authorizationHeader(): string {
-    return `Token ${this.options.apiKey}`;
+  public async connectRealtime() {
+    const client = new DeepgramClient({ apiKey: this.options.apiKey });
+    return client.listen.v1.connect({
+      model: this.options.model ?? "nova-3",
+      language: this.options.language ?? "en-US",
+      punctuate: "true",
+      interim_results: "true",
+      smart_format: String(this.options.smartFormat ?? true),
+      sentiment: String(this.options.sentiment ?? true),
+      intents: String(this.options.intents ?? true),
+      topics: String(this.options.topics ?? true)
+    } as any);
   }
 }

--- a/src/services/tts/deepgramTTS.ts
+++ b/src/services/tts/deepgramTTS.ts
@@ -1,3 +1,5 @@
+import { DeepgramClient } from "@deepgram/sdk";
+
 export interface DeepgramAuraConfig {
   apiKey: string;
   model?: string;
@@ -9,24 +11,14 @@ export class DeepgramAuraTtsService {
   constructor(private readonly config: DeepgramAuraConfig) {}
 
   public async generateTTS(text: string): Promise<ArrayBuffer> {
-    const model = this.config.model ?? "aura-luna-en";
-    const response = await fetch(`https://api.deepgram.com/v1/speak?model=${encodeURIComponent(model)}`, {
-      method: "POST",
-      headers: {
-        Authorization: `Token ${this.config.apiKey}`,
-        "Content-Type": "application/json"
-      },
-      body: JSON.stringify({
-        text,
-        encoding: this.config.encoding ?? "linear16",
-        container: this.config.container ?? "wav"
-      }),
-      signal: AbortSignal.timeout(5000)
+    const model = this.config.model ?? "aura-2-thalia-en";
+    const client = new DeepgramClient({ apiKey: this.config.apiKey });
+    const response = await client.speak.v1.audio.generate({
+      text,
+      model,
+      encoding: this.config.encoding ?? "linear16",
+      container: this.config.container ?? "wav"
     });
-
-    if (!response.ok) {
-      throw new Error(`Deepgram Aura generation failed (${response.status}).`);
-    }
 
     return response.arrayBuffer();
   }

--- a/src/services/tts/textToSpeechService.ts
+++ b/src/services/tts/textToSpeechService.ts
@@ -12,7 +12,7 @@ export class TextToSpeechService {
     if (config.ttsProvider === "deepgram_aura") {
       const key = this.secretStore.getDeepgramApiKey();
       if (!key) throw new Error("Deepgram TTS selected but DEEPGRAM_API_KEY is missing.");
-      const deepgram = new DeepgramAuraTtsService({ apiKey: key, model: "aura-luna-en", encoding: "linear16", container: "wav" });
+      const deepgram = new DeepgramAuraTtsService({ apiKey: key, model: "aura-2-thalia-en", encoding: "linear16", container: "wav" });
       const audio = await deepgram.generateTTS(text);
       return { provider: "deepgram_aura", bytes: audio.byteLength };
     }


### PR DESCRIPTION
### Motivation
- Move STT/TTS providers to the official `@deepgram/sdk` v5 APIs (Nova-3 for STT, Aura-2 for TTS) for improved accuracy and integrated intelligence features. 
- Fix a persistent issue where the Deepgram API key was not reliably saved/loaded, causing runtime 401s or blocked readiness when Deepgram is selected. 
- Ensure the app will not start when Deepgram STT/TTS is configured but the key is missing and make key availability visible in the UI and diagnostics. 

### Description
- Upgraded dependency to `@deepgram/sdk` v5 in `package.json` and `package-lock.json` and integrated the SDK client (`DeepgramClient`) for STT and TTS usage. 
- Reworked STT to use `client.listen.v1.media.transcribeFile` (and added a `listen.v1.connect` wrapper) targeting `nova-3` with `sentiment`, `topics`, and `intents` enabled, and made transcript extraction robust to response shape variations (`src/capture/sttEngine.ts`, `src/services/stt/deepgramProvider.ts`). 
- Reworked TTS to use `client.speak.v1.audio.generate` with default model `aura-2-thalia-en` and `linear16`/`wav` encoding and updated the TTS wiring (`src/services/tts/deepgramTTS.ts`, `src/services/tts/textToSpeechService.ts`). 
- Hardened secret persistence by adding explicit `DEEPGRAM_API_KEY` handling and `hasKey()` support in `SecretStore`, adding a JSON file fallback at `~/.streamsim/secrets.json` when OS keychain tooling is unavailable, and making saved values available in-process immediately (`src/security/secretStore.ts`). 
- Updated server and UI flows to use `SecretStore` diagnostics for Deepgram key presence, changed `/api/status` readiness fields to reflect persisted secrets, and made the frontend `saveCloudKey`/`saveDeepgramKey` actions trigger `refreshStatus()` so the UI shows “Present” immediately (`src/server.ts`, `src/public/app.js`). 
- Added default Deepgram STT endpoint/model references to Nova-3 and enabled intelligence flags in runtime config and UI defaults (`src/config/runtimeConfig.ts`, `src/public/app.js`). 

### Testing
- Ran `npm run build` (TypeScript compile) and it completed successfully. 
- Ran the test suite with `npm test` (`vitest`) where the overall run completed but 2 existing unrelated tests failed in `tests/hardeningFlows.test.ts` (malformed JSON parsing expectations), and these failures appear unrelated to the Deepgram/key persistence changes. 
- Performed local validation steps during development: `npm install` to upgrade the SDK and confirmed the code builds and the modified endpoints/diagnostics are exercised by the test harness.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8c2d7192c832685f66cfe1a82da7f)