### PR TITLE
docs: add Mermaid architecture diagram and system component map

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,8 @@
 # StreamSim Docs Index
 
 ## Core docs
+- [`architecture-diagram.md`](./architecture-diagram.md): end-to-end Mermaid architecture flow covering capture, intelligence, routing, safety, and rendering.
+- [`system-component-map.md`](./system-component-map.md): Mermaid component map of modules grouped by execution domains and responsibilities.
 - [`technical-spec.md`](./technical-spec.md): product vision, architecture intent, requirements, and milestone framing.
 - [`development-checklist.md`](./development-checklist.md): implementation tracking checklist mapped to features, hardening items, and acceptance evidence.
 

--- a/docs/architecture-diagram.md
+++ b/docs/architecture-diagram.md
@@ -1,0 +1,107 @@
+# StreamSim Architectural Diagram
+
+This diagram captures the end-to-end runtime architecture across capture, intelligence, inference routing, safety, anti-echo/glaze controls, identity assignment, spooling, rendering, and observability.
+
+```mermaid
+flowchart LR
+  %% External actors
+  streamer([Streamer / Mic + Camera])
+  viewerUI([Control Center UI])
+  overlay([Overlay UI / OBS Capture])
+
+  %% Runtime configuration + APIs
+  subgraph API[Server & Runtime API Layer]
+    server[server.ts\nExpress + SSE]
+    configStore[Runtime Config\nconfigStore/runtimeConfig]
+    readiness[Readiness + Compliance + NFR gates]
+  end
+
+  %% Core orchestration
+  subgraph ORCH[Simulation Control Plane]
+    orchestrator[SimulationOrchestrator]
+    sidecar[SidecarManager\n(Local model pull / control)]
+    observability[ObservabilityLogger]
+    audioState[AudioStateManager\nAnti-Echo deafen state]
+  end
+
+  %% Capture and intelligence
+  subgraph CAPTURE[Capture + Context Intelligence]
+    stt[STT Engine + Providers]
+    device[DeviceCapturePipeline\nrolling mic + vision buffers]
+    deepgramIntel[Deepgram Intelligence Mapper\n(sentiment/topic/intent -> vibe)]
+    contextAsm[Context Assembler]
+    promptBuilder[Prompt Builder]
+  end
+
+  %% Inference
+  subgraph INFER[Hybrid Inference Plane]
+    providerFactory[ProviderFactory]
+    hybrid[HybridInferenceProvider\nlocal/cloud routing + retries]
+    localLLM[(Ollama / LM Studio)]
+    cloudLLM[(OpenAI / Groq)]
+    mockLLM[(Mock Provider)]
+  end
+
+  %% Post-inference and rendering
+  subgraph RENDER[Safety + Persona Realism + Rendering]
+    parser[Output Parser\n(JSON recovery)]
+    antiEcho[Anti-Echo + Read-Chat detection]
+    glaze[Behavior diversity / anti-glaze rules]
+    safety[Safety Filter\nbanlist + compliance]
+    identity[Identity Manager\nsafe username assignment]
+    spooler[Spooling Engine\nburst timing + pacing]
+    tts[TTS Service\nDeepgram TTS + playback]
+  end
+
+  %% Primary flow
+  streamer --> stt
+  streamer --> device
+  stt --> device
+  device --> deepgramIntel
+  deepgramIntel --> contextAsm
+  device --> contextAsm
+  contextAsm --> promptBuilder
+  promptBuilder --> orchestrator
+
+  viewerUI --> server
+  server --> configStore
+  configStore --> orchestrator
+  readiness --> server
+
+  orchestrator --> sidecar
+  orchestrator --> providerFactory
+  providerFactory --> hybrid
+  hybrid --> localLLM
+  hybrid --> cloudLLM
+  hybrid --> mockLLM
+
+  localLLM --> parser
+  cloudLLM --> parser
+  mockLLM --> parser
+
+  parser --> antiEcho
+  antiEcho --> glaze
+  glaze --> safety
+  safety --> identity
+  identity --> spooler
+  spooler --> overlay
+
+  orchestrator --> observability
+  stt -. deafen while TTS .-> audioState
+  tts --> audioState
+  audioState -. pause/resume .-> stt
+
+  spooler --> tts
+  tts --> overlay
+
+  server --> overlay
+  orchestrator --> server
+```
+
+## Flow Notes
+
+1. **SimulationOrchestrator** is the control hub that drives loop timing, AI status, sidecar activity, and meta events.
+2. **DeviceCapturePipeline + Deepgram Intelligence** enrich transcript/tone/vision with vibe/topic/intent signals.
+3. **HybridInferenceProvider** performs model routing (local vs cloud), timeout-aware retries, and fallback candidate selection.
+4. **Output hardening** then applies parser recovery, anti-echo constraints, anti-glaze/diversity rules, safety filtering, identity assignment, and stochastic spooling.
+5. **AudioStateManager + TTS** enforce anti-feedback behavior so STT does not ingest generated playback.

--- a/docs/system-component-map.md
+++ b/docs/system-component-map.md
@@ -1,0 +1,113 @@
+# StreamSim System Component Map
+
+The component map below groups concrete code modules into execution domains and shows how responsibilities are partitioned.
+
+```mermaid
+flowchart TB
+  subgraph CLIENT[Client Surfaces]
+    controlCenter[src/public/index.html + app.js\nControl Center]
+    overlayView[src/public/overlay.html + overlay.js\nChat Overlay]
+  end
+
+  subgraph ENTRY[Service Entry]
+    server[src/server.ts\nHTTP + SSE + orchestration endpoints]
+  end
+
+  subgraph CONFIG[Configuration & Policy]
+    runtime[src/config/runtimeConfig.ts]
+    store[src/config/configStore.ts]
+    migrations[src/config/configMigrations.ts]
+    compliance[src/services/complianceGate.ts + complianceLogger.ts]
+    trace[src/services/nfrTraceGate.ts + readinessChecks.ts]
+  end
+
+  subgraph CAPTURE[Capture & Signal Processing]
+    sttEngine[src/capture/sttEngine.ts]
+    captureProviders[src/capture/captureProviders.ts]
+    devicePipeline[src/capture/deviceCapturePipeline.ts]
+    realism[src/llm/realismSignals.ts]
+    dgIntelligence[src/services/intelligence/deepgramIntelligence.ts]
+  end
+
+  subgraph PIPELINE[Prompt / Context Pipeline]
+    context[src/pipeline/contextAssembler.ts]
+    prompt[src/pipeline/promptBuilder.ts]
+    parser[src/pipeline/outputParser.ts]
+  end
+
+  subgraph INFERENCE[Inference Routing]
+    factory[src/llm/providerFactory.ts]
+    hybrid[src/llm/realInferenceProvider.ts\nHybrid local/cloud + retries]
+    mock[src/llm/mockInferenceProvider.ts]
+    audience[src/llm/mockAudienceGenerator.ts]
+    sidecar[src/services/sidecarManager.ts]
+  end
+
+  subgraph RUNTIME[Simulation Runtime]
+    orchestrator[src/services/simulationOrchestrator.ts]
+    spool[src/services/spoolingEngine.ts]
+    identity[src/services/identityManager.ts]
+    tts[src/services/tts/textToSpeechService.ts + deepgramTTS.ts]
+    audio[src/core/audioStateManager.ts]
+    safety[src/core/safetyFilter.ts]
+    observability[src/services/observability.ts + bootDiagnostics.ts]
+    workload[src/services/workloadRunner.ts]
+  end
+
+  subgraph SECURITY[Security & Secrets]
+    banlist[src/security/banlistRegistry.ts + banlist-source-of-truth.json]
+    diagnostics[src/security/diagnostics.ts]
+    secrets[src/security/secretStore.ts]
+  end
+
+  controlCenter --> server
+  overlayView --> server
+
+  server --> runtime
+  server --> store
+  store --> migrations
+  runtime --> compliance
+  runtime --> trace
+
+  orchestrator --> captureProviders
+  captureProviders --> sttEngine
+  sttEngine --> devicePipeline
+  devicePipeline --> realism
+  devicePipeline --> dgIntelligence
+
+  devicePipeline --> context
+  context --> prompt
+  prompt --> factory
+  factory --> hybrid
+  factory --> mock
+  hybrid --> sidecar
+
+  hybrid --> parser
+  mock --> audience
+  audience --> parser
+
+  parser --> safety
+  safety --> identity
+  identity --> spool
+  spool --> overlayView
+
+  spool --> tts
+  tts --> audio
+  audio --> sttEngine
+
+  runtime --> observability
+  runtime --> workload
+
+  identity --> banlist
+  safety --> banlist
+  orchestrator --> secrets
+  secrets --> diagnostics
+```
+
+## Legend
+
+- **Simulation Runtime**: Real-time control loop and post-inference shaping.
+- **Capture & Signal Processing**: Raw multimodal ingestion + derived behavioral intelligence.
+- **Inference Routing**: Abstraction layer that chooses local/cloud/mock providers.
+- **Configuration & Policy**: Runtime config, migration, compliance, and release gates.
+- **Security & Secrets**: Banlist governance and key handling.


### PR DESCRIPTION
### Motivation
- Provide a clear visual reference of StreamSim’s expanded runtime (capture, Deepgram intelligence, Identity Manager, Hybrid Inference routing, Anti-Echo/Glaze logic, safety/spooling, TTS, and overlay) to help developers reason about interactions and responsibilities across modules.

### Description
- Add `docs/architecture-diagram.md` (end-to-end Mermaid flow) and `docs/system-component-map.md` (Mermaid component map grouped by execution domains) and update `docs/README.md` to link both new documents.

### Testing
- Ran `npm run build` to validate the change surface; build failed due to missing `@deepgram/sdk` module/type declarations referenced in `src/capture/sttEngine.ts`, `src/services/stt/deepgramProvider.ts`, and `src/services/tts/deepgramTTS.ts`, which is unrelated to these documentation-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8c4dc87ac83268a53190ded3633cb)