### PR TITLE
Add Vision provider diagnostics, tune Deepgram finalization, and reduce chat repetition/cutoff

### DIFF
--- a/src/capture/sttEngine.ts
+++ b/src/capture/sttEngine.ts
@@ -10,7 +10,7 @@ interface SttBackend {
 }
 
 const DEFAULT_LOCAL_STT_ENDPOINT = "http://127.0.0.1:7778/stt";
-const DEFAULT_DEEPGRAM_ENDPOINT = "https://api.deepgram.com/v1/listen?model=nova-3&language=en-US&smart_format=true&filler_words=true&punctuate=true&sentiment=true&intents=true&topics=true";
+const DEFAULT_DEEPGRAM_ENDPOINT = "https://api.deepgram.com/v1/listen?model=nova-3&language=en-US&smart_format=true&filler_words=true&punctuate=true&sentiment=true&intents=true&topics=true&utterance_end_ms=3000";
 const DEFAULT_OPENAI_STT_ENDPOINT = "https://api.openai.com/v1/audio/transcriptions";
 
 class MockSttBackend implements SttBackend {

--- a/src/config/runtimeConfig.ts
+++ b/src/config/runtimeConfig.ts
@@ -18,7 +18,9 @@ export const defaultConfig: SimulationConfig = {
     visionIntervalSec: 25,
     visionProvider: "local",
     useRealCapture: true,
-    sttEndpoint: process.env.STREAMSIM_DEEPGRAM_ENDPOINT ?? "https://api.deepgram.com/v1/listen?model=nova-3&smart_format=true&filler_words=true&punctuate=true&sentiment=true&topics=true&intents=true",
+    sttEndpoint:
+      process.env.STREAMSIM_DEEPGRAM_ENDPOINT ??
+      "https://api.deepgram.com/v1/listen?model=nova-3&smart_format=true&filler_words=true&punctuate=true&sentiment=true&topics=true&intents=true&utterance_end_ms=3000",
     sttProvider: process.env.SIM_DEFAULT_STT === "deepgram_nova_2" ? "deepgram" : "local-whisper",
     visionEndpoint: "http://127.0.0.1:7778/vision-tags"
   },

--- a/src/public/app.js
+++ b/src/public/app.js
@@ -47,7 +47,7 @@ const CAMERA_FRAME_CONFIRM_TIMEOUT_MS = 3000;
 const STT_DEFAULT_ENDPOINTS = {
   "local-whisper": "http://127.0.0.1:7778/stt",
   whispercpp: "http://127.0.0.1:7778/stt",
-  deepgram: "https://api.deepgram.com/v1/listen?model=nova-3&language=en-US&smart_format=true&filler_words=true&punctuate=true&sentiment=true&topics=true&intents=true",
+  deepgram: "https://api.deepgram.com/v1/listen?model=nova-3&language=en-US&smart_format=true&filler_words=true&punctuate=true&sentiment=true&topics=true&intents=true&utterance_end_ms=3000",
   "openai-whisper": "https://api.openai.com/v1/audio/transcriptions",
   "gpt-4o-mini-transcribe": "https://api.openai.com/v1/audio/transcriptions",
   mock: "http://127.0.0.1:7778/stt"

--- a/src/services/simulationOrchestrator.ts
+++ b/src/services/simulationOrchestrator.ts
@@ -234,24 +234,7 @@ export class SimulationOrchestrator {
       next = next.replace(/\s+/g, " ").trim();
       return next;
     };
-    const trimmedWordCap = (text: string): string => {
-      const words = text.split(/\s+/).filter(Boolean);
-      return words.length > 3 ? words.slice(0, 3).join(" ") : text;
-    };
-
-    const normalized = messages.map((message) => ({ ...message, text: sanitize(message.text) }));
-    const shortTarget = Math.ceil(normalized.length * 0.8);
-    let shortCount = normalized.filter((message) => message.text.split(/\s+/).filter(Boolean).length <= 3).length;
-
-    if (shortCount >= shortTarget) return normalized;
-    return normalized.map((message) => {
-      if (shortCount >= shortTarget) return message;
-      const shortened = trimmedWordCap(message.text);
-      if (shortened !== message.text) {
-        shortCount += 1;
-      }
-      return { ...message, text: shortened };
-    });
+    return messages.map((message) => ({ ...message, text: sanitize(message.text) }));
   }
 
   private enforceDiversityRules(messages: ChatMessage[], behavioralModes: string[]): ChatMessage[] {
@@ -294,7 +277,25 @@ export class SimulationOrchestrator {
       remapped[1] = { ...remapped[1], text: contrastReplies[Math.floor(Math.random() * contrastReplies.length)] };
     }
 
-    return remapped;
+    const deduped = remapped.map((message) => ({ ...message }));
+    const seen = new Set<string>();
+    const fallbackReplies = [
+      "new take pls",
+      "same line again??",
+      "switch it up bro",
+      "different angle pls"
+    ];
+    deduped.forEach((message, index) => {
+      const key = message.text.toLowerCase().replace(/\s+/g, " ").trim();
+      if (!key) return;
+      if (seen.has(key)) {
+        message.text = fallbackReplies[index % fallbackReplies.length];
+        return;
+      }
+      seen.add(key);
+    });
+
+    return deduped;
   }
 
   private verbosePipelineLog(

--- a/src/services/stt/deepgramProvider.ts
+++ b/src/services/stt/deepgramProvider.ts
@@ -9,6 +9,7 @@ export interface DeepgramSttOptions {
   intents?: boolean;
   topics?: boolean;
   sentiment?: boolean;
+  utteranceEndMs?: number;
 }
 
 export class DeepgramNova3Provider {
@@ -21,6 +22,7 @@ export class DeepgramNova3Provider {
       language: this.options.language ?? "en-US",
       punctuate: "true",
       interim_results: "true",
+      utterance_end_ms: String(this.options.utteranceEndMs ?? 3000),
       smart_format: String(this.options.smartFormat ?? true),
       sentiment: String(this.options.sentiment ?? true),
       intents: String(this.options.intents ?? true),

--- a/src/services/visionPollingService.ts
+++ b/src/services/visionPollingService.ts
@@ -17,6 +17,11 @@ interface VisionEndpointPayload {
   dataUrl?: string;
 }
 
+interface VisionProviderResult {
+  tags: string[];
+  providerResponse: unknown;
+}
+
 function normalizeVisionTags(payload: VisionEndpointPayload): string[] {
   const listCandidates = [
     payload.visionTags,
@@ -89,20 +94,26 @@ export class VisionPollingService {
         throw new Error(`vision endpoint failed (${endpointResponse.status})`);
       }
       const endpointPayload = ((await endpointResponse.json()) ?? {}) as VisionEndpointPayload;
+      // eslint-disable-next-line no-console
+      console.log("[VisionPollingService] vision endpoint payload", endpointPayload);
 
-      const tags =
+      const providerResult: VisionProviderResult =
         config.capture.visionProvider === "openai"
           ? await this.fetchOpenAiVisionTags(config, endpointPayload)
-          : normalizeVisionTags(endpointPayload);
+          : { tags: normalizeVisionTags(endpointPayload), providerResponse: endpointPayload };
+      const tags = providerResult.tags;
 
       if (tags.length) {
         sharedDeviceCapturePipeline.ingestVisionSample({ tags });
       }
 
+      // eslint-disable-next-line no-console
+      console.log("[VisionPollingService] normalized vision tags", { tags, provider: config.capture.visionProvider });
       this.emitMeta({
         vision: {
           provider: config.capture.visionProvider,
           endpoint: config.capture.visionEndpoint,
+          providerResponse: providerResult.providerResponse,
           tags,
           updatedAt: new Date().toISOString()
         }
@@ -115,7 +126,7 @@ export class VisionPollingService {
     this.scheduleNext(delayMs);
   }
 
-  private async fetchOpenAiVisionTags(config: SimulationConfig, payload: VisionEndpointPayload): Promise<string[]> {
+  private async fetchOpenAiVisionTags(config: SimulationConfig, payload: VisionEndpointPayload): Promise<VisionProviderResult> {
     const cloudApiKey = this.secretStore.getCloudApiKey();
     if (!cloudApiKey) {
       throw new Error("Cloud API key missing for OpenAI vision provider.");
@@ -129,7 +140,7 @@ export class VisionPollingService {
       "";
 
     if (!imageInput) {
-      return normalizeVisionTags(payload);
+      return { tags: normalizeVisionTags(payload), providerResponse: payload };
     }
 
     const response = await fetch(config.provider.cloudEndpoint, {
@@ -168,6 +179,8 @@ export class VisionPollingService {
       choices?: Array<{ message?: { content?: string | Array<{ text?: string }> } }>;
       output_text?: string;
     };
+    // eslint-disable-next-line no-console
+    console.log("[VisionPollingService] openai vision response", data);
 
     const content = data.choices?.[0]?.message?.content;
     const text =
@@ -177,10 +190,13 @@ export class VisionPollingService {
           ? content.map((part) => part.text ?? "").join(" ")
           : data.output_text ?? "";
 
-    return text
+    return {
+      providerResponse: data,
+      tags: text
       .split(",")
       .map((tag) => tag.trim().toLowerCase())
       .filter(Boolean)
-      .slice(0, 8);
+      .slice(0, 8)
+    };
   }
 }

--- a/tests/antiEcho.test.ts
+++ b/tests/antiEcho.test.ts
@@ -148,4 +148,47 @@ describe("anti-echo constraint", () => {
     expect(diverse[0].text).toContain("gyatt");
     expect(diverse[1].text).toContain("simps");
   });
+
+  it("keeps full phrases instead of force-trimming most messages to 3 words", () => {
+    const orchestrator = makeOrchestrator();
+    const input: ChatMessage[] = [
+      {
+        id: "1",
+        username: "user1",
+        text: "this sentence should stay fully readable and not be cut",
+        emotes: [],
+        donationCents: null,
+        ttsText: null,
+        createdAt: new Date().toISOString()
+      }
+    ];
+    const normalized = (orchestrator as any).enforcePersonaSyntax(input);
+    expect(normalized[0].text.split(/\s+/).length).toBeGreaterThan(3);
+  });
+
+  it("rewrites duplicate nearby messages to improve diversity", () => {
+    const orchestrator = makeOrchestrator();
+    const input: ChatMessage[] = [
+      {
+        id: "1",
+        username: "user1",
+        text: "mic check passed",
+        emotes: [],
+        donationCents: null,
+        ttsText: null,
+        createdAt: new Date().toISOString()
+      },
+      {
+        id: "2",
+        username: "user2",
+        text: "mic check passed",
+        emotes: [],
+        donationCents: null,
+        ttsText: null,
+        createdAt: new Date().toISOString()
+      }
+    ];
+    const diverse = (orchestrator as any).enforceDiversityRules(input, ["default"]);
+    expect(diverse[1].text.toLowerCase()).not.toBe("mic check passed");
+  });
 });

--- a/tests/captureProviders.test.ts
+++ b/tests/captureProviders.test.ts
@@ -66,4 +66,39 @@ describe("VisionPollingService", () => {
     const context = sharedDeviceCapturePipeline.getContext(config);
     expect(context.visionTags).toEqual(["green hoodie", "gaming headset"]);
   });
+
+  it("emits provider response details for vision diagnostics", async () => {
+    const config = {
+      ...defaultConfig,
+      capture: {
+        ...defaultConfig.capture,
+        visionEnabled: true,
+        useRealCapture: true,
+        visionProvider: "local" as const,
+        visionIntervalSec: 5,
+        visionEndpoint: "http://127.0.0.1:7778/vision-tags"
+      }
+    };
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ visionTags: ["ring light"] })
+      }))
+    );
+
+    const emitMeta = vi.fn();
+    const service = new VisionPollingService(() => config, emitMeta);
+    await (service as any).tick();
+
+    expect(emitMeta).toHaveBeenCalledWith(
+      expect.objectContaining({
+        vision: expect.objectContaining({
+          providerResponse: { visionTags: ["ring light"] },
+          tags: ["ring light"]
+        })
+      })
+    );
+  });
 });


### PR DESCRIPTION
### Motivation
- Make Vision failures and empty results diagnosable by surfacing the exact provider payload alongside normalized tags so the Orchestrator can tell whether Vision is running or failing. 
- Reduce STT clipping where Deepgram finalizes too early by aligning default endpoints and realtime options with a longer `utterance_end_ms` timeout. 
- Stop server-side truncation and decrease repetitive chat output so overlay messages are readable and not repeatedly identical.

### Description
- VisionPollingService now logs the raw endpoint payload and emits `providerResponse` with normalized `tags` in meta so endpoint/OpenAI responses are visible in diagnostics. (changes in `src/services/visionPollingService.ts`).
- OpenAI vision fetch now returns a `VisionProviderResult` containing both `tags` and the raw provider response for emission and logging. (changes in `fetchOpenAiVisionTags`).
- Deepgram STT defaults were updated to include `utterance_end_ms=3000` in runtime/UI presets and `DeepgramNova3Provider` now supports an `utteranceEndMs` option used for realtime connects to reduce premature finalization. (changes in `src/capture/sttEngine.ts`, `src/config/runtimeConfig.ts`, `src/public/app.js`, `src/services/stt/deepgramProvider.ts`).
- Removed aggressive 3-word truncation in persona normalization so messages remain readable and full-length, and added a dedupe/rewriting pass in diversity enforcement to replace very close duplicate nearby messages with alternate replies. (changes in `src/services/simulationOrchestrator.ts`).
- Added tests to cover Vision provider response emission, preserving readable message length, and rewriting duplicate nearby messages. (changes in `tests/captureProviders.test.ts` and `tests/antiEcho.test.ts`).

### Testing
- Ran `npm test -- tests/antiEcho.test.ts tests/captureProviders.test.ts` and the targeted suites passed locally. 
- Installed dev dependencies with `npm install` to resolve `@deepgram/sdk` for the test environment and re-ran tests; full test run completed with all tests passing. 
- Built the TypeScript output with `npm run build` and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9526923a0832698ba5293c3af8edc)