### PR TITLE
Realism Patch 2.7: Fix vision handoff, hardware brevity caps, transcript decay & STT biasing

### DIFF
--- a/src/capture/sttEngine.ts
+++ b/src/capture/sttEngine.ts
@@ -12,6 +12,14 @@ interface SttBackend {
 const DEFAULT_LOCAL_STT_ENDPOINT = "http://127.0.0.1:7778/stt";
 const DEFAULT_DEEPGRAM_ENDPOINT = "https://api.deepgram.com/v1/listen?model=nova-3&language=en-US&smart_format=true&filler_words=true&punctuate=true&sentiment=true&intents=true&topics=true&utterance_end_ms=3000";
 const DEFAULT_OPENAI_STT_ENDPOINT = "https://api.openai.com/v1/audio/transcriptions";
+const DEEPGRAM_STREAMER_BIAS_KEYWORDS = [
+  "up stream:3",
+  "stream sim:2",
+  "what's up stream:2.5",
+  "what is up stream:2.5",
+  "chat:1.5",
+  "gg:1.5"
+];
 
 class MockSttBackend implements SttBackend {
   public async transcribe(frame: Buffer): Promise<string> {
@@ -65,8 +73,9 @@ class DeepgramBackend implements SttBackend {
         punctuate: true,
         sentiment: true,
         intents: true,
-        topics: true
-      });
+        topics: true,
+        keywords: DEEPGRAM_STREAMER_BIAS_KEYWORDS
+      } as any);
       const payload = response as unknown as {
         results?: { channels?: Array<{ alternatives?: Array<{ transcript?: string }> }> };
         result?: { results?: { channels?: Array<{ alternatives?: Array<{ transcript?: string }> }> } };

--- a/src/llm/realInferenceProvider.ts
+++ b/src/llm/realInferenceProvider.ts
@@ -234,7 +234,12 @@ function systemPromptForPayload(payload: PromptPayload): string {
     "Keep most messages short fragments, meme slang, or reactions like 'w', 'l', 'lmao', 'ratio', 'wait what', 'cap', 'trippin', 'idk', 'cooked', 'bro what', 'we are so back', 'yooo', 'glazing', 'fraud', 'delusional'.",
     `Emotes rule: emotes array may contain only unicode emoji or one of [${ALLOWED_TEXT_EMOTES.join(", ")}]. Never invent emote names.`,
     "Some viewers should be emote-only (message text can be empty while emotes are populated).",
-    "Only set ttsText when donationCents is a positive number. Otherwise ttsText must be null."
+    "Only set ttsText when donationCents is a positive number. Otherwise ttsText must be null.",
+    "DIVERSITY ANCHORS: vary sentence openers every message (examples: nah, bro, wait, yo, lowkey, fr, ngl, idk, tbh).",
+    "DIVERSITY ANCHORS: rotate message shape across the batch (question, short take, emote-only, roast, agreement).",
+    "Ignorance Clause: If streamer asks about a term you don't know, DO NOT invent a definition. React with: '??', 'who?', 'bro is yapping', or 'lmao what'.",
+    "Repetition Ban: You are forbidden from using the same adjective twice in a 4-message window. Rotate slang constantly.",
+    "No Explanations: NEVER drone on to explain anything. If asked a question, give a short opinion or a 1-word guess. Maybe one chatter answers seriously."
   ].join(" ");
 }
 
@@ -280,11 +285,6 @@ function buildModelFacingPayload(payload: PromptPayload): Record<string, unknown
     personaCalibration: payload.personaCalibration,
     providerConditioning: payload.providerConditioning
   };
-}
-
-function cloudModelSupportsTemperature(model: string): boolean {
-  const normalized = model.trim().toLowerCase();
-  return !/^gpt-5(?:$|[.:-])/.test(normalized);
 }
 
 const CLOUD_MODEL_FALLBACKS: Record<string, string[]> = {
@@ -421,16 +421,16 @@ export class HybridInferenceProvider implements InferenceProvider {
     for (const model of cloudModelCandidates(config.provider.cloudModel)) {
       const body: {
         model: string;
-        temperature?: number;
         messages: Array<{ role: "system" | "user"; content: string }>;
         response_format?: ReturnType<typeof openAiResponseSchema>;
+        max_tokens: number;
+        max_completion_tokens: number;
       } = {
         model,
-        messages
+        messages,
+        max_tokens: 12,
+        max_completion_tokens: 15
       };
-      if (cloudModelSupportsTemperature(model)) {
-        body.temperature = 0.8;
-      }
       if (this.mode === "openai") {
         body.response_format = openAiResponseSchema(payload.requestedMessageCount);
       }

--- a/src/services/simulationOrchestrator.ts
+++ b/src/services/simulationOrchestrator.ts
@@ -29,6 +29,7 @@ export class SimulationOrchestrator {
     () => this.getConfig(),
     (meta) => this.emitMeta(meta)
   );
+  private readonly transcriptSeenCounter = new Map<string, { count: number; lastSeenAt: number }>();
   private recentChatHistory: string[] = [];
   private aiStatus: {
     state: "idle" | "running" | "degraded" | "error";
@@ -77,6 +78,7 @@ export class SimulationOrchestrator {
     this.audioState.stopTts();
     sharedSttEngine.resume();
     sharedDeviceCapturePipeline.reset();
+    this.transcriptSeenCounter.clear();
   }
 
   public cancelSidecarPull(): void {
@@ -298,6 +300,26 @@ export class SimulationOrchestrator {
     return deduped;
   }
 
+  private applyTranscriptDecay(context: PromptPayload["context"]): PromptPayload["context"] {
+    const normalized = context.transcript.trim().toLowerCase();
+    if (!normalized) return context;
+
+    const now = Date.now();
+    for (const [key, value] of this.transcriptSeenCounter.entries()) {
+      if (now - value.lastSeenAt > 90_000) {
+        this.transcriptSeenCounter.delete(key);
+      }
+    }
+
+    const existing = this.transcriptSeenCounter.get(normalized);
+    const seenCount = existing?.count ?? 0;
+    this.transcriptSeenCounter.set(normalized, { count: seenCount + 1, lastSeenAt: now });
+    if (seenCount >= 3) {
+      return { ...context, transcript: "" };
+    }
+    return context;
+  }
+
   private verbosePipelineLog(
     route: "primary" | "fallback",
     providerMode: string,
@@ -364,10 +386,11 @@ export class SimulationOrchestrator {
 
       const captureStarted = Date.now();
       const capturedContext = await captureProvider.getContext(config);
-      const context = {
+      const contextWithHistory = {
         ...capturedContext,
         recentChatHistory: this.recentChatHistory.slice(0, 20)
       };
+      const context = this.applyTranscriptDecay(contextWithHistory);
       const captureLatencyMs = Date.now() - captureStarted;
 
       timing = this.spooler.nextDelayMs(config, context.tone);

--- a/src/services/stt/deepgramProvider.ts
+++ b/src/services/stt/deepgramProvider.ts
@@ -26,7 +26,8 @@ export class DeepgramNova3Provider {
       smart_format: String(this.options.smartFormat ?? true),
       sentiment: String(this.options.sentiment ?? true),
       intents: String(this.options.intents ?? true),
-      topics: String(this.options.topics ?? true)
+      topics: String(this.options.topics ?? true),
+      keywords: "up stream:3,what's up stream:2.5,stream sim:2,chat:1.5"
     } as any);
   }
 }

--- a/src/services/visionPollingService.ts
+++ b/src/services/visionPollingService.ts
@@ -48,6 +48,16 @@ function normalizeVisionTags(payload: VisionEndpointPayload): string[] {
     .slice(0, 8);
 }
 
+function parseVisionTagsFromText(rawText: string): string[] {
+  return rawText
+    .split(/[,\n;|]/g)
+    .map((chunk) => chunk.trim())
+    .map((chunk) => chunk.replace(/^[-*•\d.)\s]+/, "").trim())
+    .map((chunk) => chunk.replace(/^["'`]+|["'`]+$/g, "").trim().toLowerCase())
+    .filter(Boolean)
+    .slice(0, 8);
+}
+
 export class VisionPollingService {
   private timer: NodeJS.Timeout | null = null;
   private running = false;
@@ -101,6 +111,8 @@ export class VisionPollingService {
         config.capture.visionProvider === "openai"
           ? await this.fetchOpenAiVisionTags(config, endpointPayload)
           : { tags: normalizeVisionTags(endpointPayload), providerResponse: endpointPayload };
+      // eslint-disable-next-line no-console
+      console.log("[VisionService] Raw response from provider:", providerResult.providerResponse);
       const tags = providerResult.tags;
 
       if (tags.length) {
@@ -180,7 +192,7 @@ export class VisionPollingService {
       output_text?: string;
     };
     // eslint-disable-next-line no-console
-    console.log("[VisionPollingService] openai vision response", data);
+    console.log("[VisionService] Raw response from provider:", data);
 
     const content = data.choices?.[0]?.message?.content;
     const text =
@@ -192,11 +204,7 @@ export class VisionPollingService {
 
     return {
       providerResponse: data,
-      tags: text
-      .split(",")
-      .map((tag) => tag.trim().toLowerCase())
-      .filter(Boolean)
-      .slice(0, 8)
+      tags: parseVisionTagsFromText(text)
     };
   }
 }

--- a/tests/antiEcho.test.ts
+++ b/tests/antiEcho.test.ts
@@ -191,4 +191,25 @@ describe("anti-echo constraint", () => {
     const diverse = (orchestrator as any).enforceDiversityRules(input, ["default"]);
     expect(diverse[1].text.toLowerCase()).not.toBe("mic check passed");
   });
+
+  it("applies transcript decay after the same transcript is seen three times", () => {
+    const orchestrator = makeOrchestrator();
+    const baseContext = {
+      transcript: "same line from streamer",
+      tone: { volumeRms: 0.4, paceWpm: 120 },
+      visionTags: [],
+      recentChatHistory: [],
+      timestamp: new Date().toISOString()
+    };
+
+    const first = (orchestrator as any).applyTranscriptDecay(baseContext);
+    const second = (orchestrator as any).applyTranscriptDecay(baseContext);
+    const third = (orchestrator as any).applyTranscriptDecay(baseContext);
+    const fourth = (orchestrator as any).applyTranscriptDecay(baseContext);
+
+    expect(first.transcript).toBe("same line from streamer");
+    expect(second.transcript).toBe("same line from streamer");
+    expect(third.transcript).toBe("same line from streamer");
+    expect(fourth.transcript).toBe("");
+  });
 });

--- a/tests/captureProviders.test.ts
+++ b/tests/captureProviders.test.ts
@@ -37,6 +37,7 @@ describe("VisionPollingService", () => {
   beforeEach(() => {
     sharedDeviceCapturePipeline.reset();
     vi.restoreAllMocks();
+    process.env.STREAMSIM_CLOUD_API_KEY = "test-cloud-key";
   });
 
   it("ingests local vision tags asynchronously", async () => {
@@ -100,5 +101,41 @@ describe("VisionPollingService", () => {
         })
       })
     );
+  });
+
+  it("maps OpenAI vision output text back into context.visionTags", async () => {
+    const config = {
+      ...defaultConfig,
+      provider: { ...defaultConfig.provider, cloudEndpoint: "https://api.openai.com/v1/chat/completions", cloudModel: "gpt-4o-mini" },
+      capture: {
+        ...defaultConfig.capture,
+        visionEnabled: true,
+        useRealCapture: true,
+        visionProvider: "openai" as const,
+        visionIntervalSec: 5,
+        visionEndpoint: "http://127.0.0.1:7778/vision-tags"
+      }
+    };
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/vision-tags")) {
+        return {
+          ok: true,
+          json: async () => ({ imageBase64: "abcd1234==" })
+        };
+      }
+      return {
+        ok: true,
+        json: async () => ({ choices: [{ message: { content: "green hoodie, gaming headset, ring light" } }] })
+      };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const service = new VisionPollingService(() => config, () => undefined);
+    await (service as any).tick();
+
+    const context = sharedDeviceCapturePipeline.getContext(config);
+    expect(context.visionTags).toEqual(["green hoodie", "gaming headset", "ring light"]);
   });
 });

--- a/tests/integrationRouting.test.ts
+++ b/tests/integrationRouting.test.ts
@@ -239,7 +239,9 @@ describe("hybrid routing and failover", () => {
       req.on("end", () => {
         const parsed = JSON.parse(body);
         expect(parsed.messages[1].role).toBe("user");
-        expect(parsed.temperature).toBe(0.8);
+        expect(parsed.max_tokens).toBe(12);
+        expect(parsed.max_completion_tokens).toBe(15);
+        expect(parsed.temperature).toBeUndefined();
         res.writeHead(200, { "Content-Type": "application/json" });
         res.end(JSON.stringify({ choices: [{ message: { content: '{"messages":[]}' } }] }));
       });
@@ -303,7 +305,7 @@ describe("hybrid routing and failover", () => {
     await server.close();
   });
 
-  it("omits temperature for GPT-5 family cloud models", async () => {
+  it("applies hardware brevity token limits for GPT-5 family cloud models", async () => {
     process.env.STREAMSIM_CLOUD_API_KEY = "abc123";
     const server = await withTestServer((req, res) => {
       if (req.method !== "POST") {
@@ -317,6 +319,8 @@ describe("hybrid routing and failover", () => {
       req.on("end", () => {
         const parsed = JSON.parse(body);
         expect(parsed.model).toBe("gpt-5-mini");
+        expect(parsed.max_tokens).toBe(12);
+        expect(parsed.max_completion_tokens).toBe(15);
         expect(parsed.temperature).toBeUndefined();
         res.writeHead(200, { "Content-Type": "application/json" });
         res.end(JSON.stringify({ choices: [{ message: { content: '{"messages":[]}' } }] }));


### PR DESCRIPTION
### Motivation
- Vision tags occasionally never reached the inference payload even when UI showed "active", so provider responses must be surfaced and OpenAI Vision outputs normalized back into `PromptPayload.context.visionTags` before inference. 
- GPT-5 family models do not support frequency/presence penalties, so we must enforce short outputs by limiting tokens at the API level (`max_tokens`/`max_completion_tokens`).
- The system was stuck in repetition loops (“Ratio Chatter” / hallucination loops), so identical transcripts need TTL/seen-count decay to force topic movement.
- STT mishearings require biasing the STT provider toward streamer-specific phrases to reduce false recognitions.

### Description
- Vision pipeline: added `parseVisionTagsFromText` and verbose logging lines `"[VisionService] Raw response from provider: ..."` and ensured OpenAI vision responses are parsed and mapped into `sharedDeviceCapturePipeline` so `context.visionTags` is populated for inference (`src/services/visionPollingService.ts`).
- Hardware brevity: removed automatic temperature injection for cloud requests and added hard caps `max_tokens: 12` and `max_completion_tokens: 15` on cloud payloads to force short completions (`src/llm/realInferenceProvider.ts`).
- Transcript decay: implemented a seen-counter with a 90s TTL in `SimulationOrchestrator` and suppress the transcript (set to empty) once the same normalized transcript has been seen 3 times, preventing the 4th call from including it in `PromptPayload` (`src/services/simulationOrchestrator.ts`).
- Prompt patch: appended anti-hallucination / diversity anchors (Ignorance Clause, Repetition Ban, No Explanations, and diversity anchors) to the tail of the system prompt to bias behavior (`src/llm/realInferenceProvider.ts`).
- STT biasing: added Deepgram streamer-bias `keywords` for file transcription and realtime connection params and a local `DEEPGRAM_STREAMER_BIAS_KEYWORDS` list to improve recognition for phrases like "up stream" (`src/capture/sttEngine.ts`, `src/services/stt/deepgramProvider.ts`).
- Tests: added/updated tests to assert OpenAI vision mapping into `context.visionTags`, cloud request brevity caps, and transcript decay behavior (`tests/captureProviders.test.ts`, `tests/integrationRouting.test.ts`, `tests/antiEcho.test.ts`).

### Testing
- Ran: `npm test -- --run tests/captureProviders.test.ts tests/integrationRouting.test.ts tests/antiEcho.test.ts` and all targeted tests passed (3 test files, 28 tests total — all green).
- Unit/integ assertions added/updated to verify `visionTags` mapping from OpenAI output, presence of `max_tokens`/`max_completion_tokens` and absence of temperature for GPT-5 family, and transcript decay after 3 identical sends; these tests succeeded in the CI run described above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c95bd918b48324adf08709b6dbd8f8)