### PR TITLE
Add vision runtime status to Runtime Verification UI

### DIFF
--- a/src/public/app.js
+++ b/src/public/app.js
@@ -9,6 +9,7 @@ const aiHealthSummary = document.getElementById("aiHealthSummary");
 const aiActiveModelLabel = document.getElementById("aiActiveModelLabel");
 const ttsHealthSummary = document.getElementById("ttsHealthSummary");
 const sttHealthSummary = document.getElementById("sttHealthSummary");
+const visionHealthSummary = document.getElementById("visionHealthSummary");
 const liveMonitorEnabled = document.getElementById("liveMonitorEnabled");
 const liveMonitorStatus = document.getElementById("liveMonitorStatus");
 const liveVideo = document.getElementById("liveVideo");
@@ -662,6 +663,46 @@ function summarizeSttHealth(payload) {
   ].join("\n");
 }
 
+function summarizeVisionHealth(payload) {
+  if (!visionHealthSummary) return;
+  const capture = payload.config?.capture ?? {};
+  const enabled = Boolean(capture.visionEnabled);
+  const provider = capture.visionProvider ?? "local";
+  const useRealCapture = Boolean(capture.useRealCapture);
+  const endpoint = capture.visionEndpoint ?? "n/a";
+  const hasVisionSample = Boolean(payload.privacy?.captureBuffer?.hasVisionSample);
+  const hasCloudKey = Boolean(payload.secrets?.hasCloudKey);
+
+  let ready = true;
+  let detail = "ready";
+  if (!enabled) {
+    detail = "vision capture disabled";
+  } else if (!useRealCapture) {
+    detail = "simulated capture mode (real vision polling optional)";
+  } else if (!endpoint.startsWith("http")) {
+    ready = false;
+    detail = "Vision endpoint must be a valid URL";
+  } else if (provider === "openai" && !hasCloudKey) {
+    ready = false;
+    detail = "OpenAI vision selected but no cloud API key is stored";
+  }
+
+  const sampleStatus = enabled
+    ? hasVisionSample
+      ? "latest sample present"
+      : "waiting for first sample"
+    : "not collecting";
+
+  visionHealthSummary.textContent = [
+    `Vision enabled: ${enabled ? "yes" : "no"}`,
+    `Vision provider: ${provider}`,
+    `Capture mode: ${useRealCapture ? "real" : "simulated"}`,
+    `Vision ready: ${ready ? "yes" : "no"}`,
+    `Sample state: ${sampleStatus}`,
+    `Detail: ${detail}`
+  ].join("\n");
+}
+
 function renderDeviceChecks(result) {
   deviceChecks.innerHTML = "";
   const cameraPermissionDetail = result.cameraPermission
@@ -971,6 +1012,7 @@ async function refreshStatus() {
   summarizeAiHealth(payload);
   summarizeTtsHealth(payload);
   summarizeSttHealth(payload);
+  summarizeVisionHealth(payload);
   return payload;
 }
 
@@ -1081,6 +1123,7 @@ completeWizardBtn.addEventListener("click", async () => {
   summarizeAiHealth(status);
   summarizeTtsHealth(status);
   summarizeSttHealth(status);
+  summarizeVisionHealth(status);
 });
 
 
@@ -1177,6 +1220,7 @@ async function boot() {
   summarizeAiHealth(payload);
   summarizeTtsHealth(payload);
   summarizeSttHealth(payload);
+  summarizeVisionHealth(payload);
   latestDeviceVerification = { micPermission: false, cameraPermission: false, hasMicDevice: false, hasCameraDevice: false, cameraPermissionState: "unknown", cameraFailureReason: null };
   if (liveMonitorEnabled) {
     liveMonitorEnabled.checked = false;

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -164,6 +164,7 @@
           <pre id="aiHealthSummary">AI health pending...</pre>
           <pre id="ttsHealthSummary">TTS health pending...</pre>
           <pre id="sttHealthSummary">STT health pending...</pre>
+          <pre id="visionHealthSummary">Vision health pending...</pre>
           <label class="live-monitor-toggle"><input id="liveMonitorEnabled" type="checkbox" /> Enable live camera + voice monitor</label>
           <p id="liveMonitorStatus" class="monitor-status">Live monitor disabled.</p>
           <p id="sttCaptionStatus" class="monitor-status">Run Verify Microphone to start mic/STT check.</p>

--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -219,6 +219,11 @@ pre { margin-top: 12px; background: #0c0e14; border: 1px solid #293145; border-r
   margin-top: 8px;
 }
 
+#visionHealthSummary {
+  min-height: 82px;
+  margin-top: 8px;
+}
+
 .caption-preview {
   min-height: 56px;
   margin-bottom: 8px;


### PR DESCRIPTION
### Motivation
- Surface Vision capture health alongside AI/TTS/STT checks in the control center so operators can see vision readiness and sample state at a glance.

### Description
- Added a `pre` element `visionHealthSummary` to `src/public/index.html` and a matching CSS block in `src/public/styles.css` for consistent sizing.
- Exposed `visionHealthSummary` in `src/public/app.js` and implemented `summarizeVisionHealth(payload)` to report enabled state, provider, capture mode, readiness, sample availability (from `privacy.captureBuffer.hasVisionSample`), and actionable detail messages for invalid endpoint or missing cloud API key.
- Wired `summarizeVisionHealth` into the existing status refresh flows (`boot`, manual refresh, and onboarding completion) so it updates from the existing `/api/status` payload without backend changes.

### Testing
- Ran `npm run build` which completed successfully.
- Ran `npm test` which executed the test suite; the run showed 2 failing tests in `tests/hardeningFlows.test.ts` that are unrelated to this UI-only change while the remaining tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9729d17308324a62964902430719f)