### PR TITLE
Add API key health summary (TTS/STT/Audio Intelligence) to Runtime Verification

### DIFF
--- a/src/public/app.js
+++ b/src/public/app.js
@@ -9,6 +9,7 @@ const aiHealthSummary = document.getElementById("aiHealthSummary");
 const aiActiveModelLabel = document.getElementById("aiActiveModelLabel");
 const ttsHealthSummary = document.getElementById("ttsHealthSummary");
 const sttHealthSummary = document.getElementById("sttHealthSummary");
+const apiKeyHealthSummary = document.getElementById("apiKeyHealthSummary");
 const visionHealthSummary = document.getElementById("visionHealthSummary");
 const liveMonitorEnabled = document.getElementById("liveMonitorEnabled");
 const liveMonitorStatus = document.getElementById("liveMonitorStatus");
@@ -703,6 +704,48 @@ function summarizeVisionHealth(payload) {
   ].join("\n");
 }
 
+function summarizeApiKeyHealth(payload) {
+  if (!apiKeyHealthSummary) return;
+  const config = payload?.config ?? {};
+  const capture = config.capture ?? {};
+  const secrets = payload?.secrets ?? {};
+
+  const hasCloudKey = Boolean(secrets.hasCloudKey);
+  const hasDeepgramKey = Boolean(secrets.hasDeepgramKey);
+  const ttsEnabled = Boolean(config.ttsEnabled) && (config.ttsMode ?? "local") !== "off";
+  const ttsProvider = config.ttsProvider ?? "local";
+  const sttProvider = capture.sttProvider ?? "mock";
+  const useRealCapture = Boolean(capture.useRealCapture);
+  const audioIntelligenceEnabled = Boolean(config.audioIntelligence?.enabled);
+
+  const ttsKeyRequired = ttsEnabled && (ttsProvider === "openai" || ttsProvider === "deepgram_aura");
+  const ttsKeyStatus = !ttsKeyRequired
+    ? "not required"
+    : ttsProvider === "deepgram_aura"
+      ? hasDeepgramKey ? "present (Deepgram)" : "missing (Deepgram)"
+      : hasCloudKey ? "present (cloud)" : "missing (cloud)";
+
+  const sttKeyRequired = useRealCapture && (sttProvider === "deepgram" || sttProvider === "openai-whisper" || sttProvider === "gpt-4o-mini-transcribe");
+  const sttKeyStatus = !sttKeyRequired
+    ? "not required"
+    : sttProvider === "deepgram"
+      ? hasDeepgramKey ? "present (Deepgram)" : "missing (Deepgram)"
+      : hasCloudKey ? "present (cloud)" : "missing (cloud)";
+
+  const audioIntelligenceKeyRequired = audioIntelligenceEnabled && useRealCapture && sttProvider === "deepgram";
+  const audioIntelligenceKeyStatus = !audioIntelligenceKeyRequired
+    ? "not required"
+    : hasDeepgramKey ? "present (Deepgram)" : "missing (Deepgram)";
+
+  apiKeyHealthSummary.textContent = [
+    `TTS API key: ${ttsKeyStatus}`,
+    `STT API key: ${sttKeyStatus}`,
+    `Audio intelligence API key: ${audioIntelligenceKeyStatus}`,
+    `Cloud key detected: ${hasCloudKey ? "yes" : "no"}`,
+    `Deepgram key detected: ${hasDeepgramKey ? "yes" : "no"}`
+  ].join("\n");
+}
+
 function renderDeviceChecks(result) {
   deviceChecks.innerHTML = "";
   const cameraPermissionDetail = result.cameraPermission
@@ -1012,6 +1055,7 @@ async function refreshStatus() {
   summarizeAiHealth(payload);
   summarizeTtsHealth(payload);
   summarizeSttHealth(payload);
+  summarizeApiKeyHealth(payload);
   summarizeVisionHealth(payload);
   return payload;
 }
@@ -1123,6 +1167,7 @@ completeWizardBtn.addEventListener("click", async () => {
   summarizeAiHealth(status);
   summarizeTtsHealth(status);
   summarizeSttHealth(status);
+  summarizeApiKeyHealth(status);
   summarizeVisionHealth(status);
 });
 
@@ -1220,6 +1265,7 @@ async function boot() {
   summarizeAiHealth(payload);
   summarizeTtsHealth(payload);
   summarizeSttHealth(payload);
+  summarizeApiKeyHealth(payload);
   summarizeVisionHealth(payload);
   latestDeviceVerification = { micPermission: false, cameraPermission: false, hasMicDevice: false, hasCameraDevice: false, cameraPermissionState: "unknown", cameraFailureReason: null };
   if (liveMonitorEnabled) {

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -164,6 +164,7 @@
           <pre id="aiHealthSummary">AI health pending...</pre>
           <pre id="ttsHealthSummary">TTS health pending...</pre>
           <pre id="sttHealthSummary">STT health pending...</pre>
+          <pre id="apiKeyHealthSummary">API key status pending...</pre>
           <pre id="visionHealthSummary">Vision health pending...</pre>
           <label class="live-monitor-toggle"><input id="liveMonitorEnabled" type="checkbox" /> Enable live camera + voice monitor</label>
           <p id="liveMonitorStatus" class="monitor-status">Live monitor disabled.</p>


### PR DESCRIPTION
### Motivation
- Surface API key readiness for TTS, STT, and audio intelligence in the Runtime Verification panel so operators can quickly see required vs present keys.
- Reduce confusion when features (TTS/STT/audio intelligence) appear enabled but are missing backend credentials.

### Description
- Added an `apiKeyHealthSummary` block to the Runtime Verification UI (`src/public/index.html`).
- Implemented `summarizeApiKeyHealth(payload)` in `src/public/app.js` to compute required-vs-present status for TTS, STT, and audio intelligence keys and show cloud/Deepgram detections.
- Wired `summarizeApiKeyHealth` into status refresh paths including initial boot, manual refresh, and onboarding completion so the panel updates with other health summaries.

### Testing
- Ran `npm run build` which completed successfully.
- Ran the UI unit tests with `npm run test -- tests/uiRuntimeVerification.test.ts` and all tests passed (4 tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c974bd33188324823a0d8b056ec89d)