### PR TITLE
Replace chat request max_tokens with max_completion_tokens (35)

### DIFF
--- a/src/llm/realInferenceProvider.ts
+++ b/src/llm/realInferenceProvider.ts
@@ -423,13 +423,11 @@ export class HybridInferenceProvider implements InferenceProvider {
         model: string;
         messages: Array<{ role: "system" | "user"; content: string }>;
         response_format?: ReturnType<typeof openAiResponseSchema>;
-        max_tokens: number;
         max_completion_tokens: number;
       } = {
         model,
         messages,
-        max_tokens: 12,
-        max_completion_tokens: 15
+        max_completion_tokens: 35
       };
       if (this.mode === "openai") {
         body.response_format = openAiResponseSchema(payload.requestedMessageCount);

--- a/tests/integrationRouting.test.ts
+++ b/tests/integrationRouting.test.ts
@@ -239,8 +239,8 @@ describe("hybrid routing and failover", () => {
       req.on("end", () => {
         const parsed = JSON.parse(body);
         expect(parsed.messages[1].role).toBe("user");
-        expect(parsed.max_tokens).toBe(12);
-        expect(parsed.max_completion_tokens).toBe(15);
+        expect(parsed.max_tokens).toBeUndefined();
+        expect(parsed.max_completion_tokens).toBe(35);
         expect(parsed.temperature).toBeUndefined();
         res.writeHead(200, { "Content-Type": "application/json" });
         res.end(JSON.stringify({ choices: [{ message: { content: '{"messages":[]}' } }] }));
@@ -319,8 +319,8 @@ describe("hybrid routing and failover", () => {
       req.on("end", () => {
         const parsed = JSON.parse(body);
         expect(parsed.model).toBe("gpt-5-mini");
-        expect(parsed.max_tokens).toBe(12);
-        expect(parsed.max_completion_tokens).toBe(15);
+        expect(parsed.max_tokens).toBeUndefined();
+        expect(parsed.max_completion_tokens).toBe(35);
         expect(parsed.temperature).toBeUndefined();
         res.writeHead(200, { "Content-Type": "application/json" });
         res.end(JSON.stringify({ choices: [{ message: { content: '{"messages":[]}' } }] }));


### PR DESCRIPTION
### Motivation
- The GPT-5.4-nano runtime requires the use of `max_completion_tokens` to enforce output length limits instead of `max_tokens`, and we need a short 35-token cap to leave JSON wrapper headroom.

### Description
- Removed `max_tokens` from the cloud chat-completions request body in `src/llm/realInferenceProvider.ts` and set `max_completion_tokens` to `35`.
- Updated the TypeScript request shape to omit `max_tokens` and use `max_completion_tokens` only.
- Updated `tests/integrationRouting.test.ts` to assert that `parsed.max_tokens` is `undefined` and `parsed.max_completion_tokens` equals `35` for affected scenarios.

### Testing
- Ran `npx vitest run tests/integrationRouting.test.ts` and the test file passed with all tests green (`16 passed`).
- Attempting `npm test -- --runInBand tests/integrationRouting.test.ts` failed because `vitest` in this repo does not support the `--runInBand` option.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c977fe5a748324af8da88518735570)