### PR TITLE
Harden chat realism and vision fallback reliability

### DIFF
--- a/src/llm/realInferenceProvider.ts
+++ b/src/llm/realInferenceProvider.ts
@@ -224,6 +224,8 @@ function systemPromptForPayload(payload: PromptPayload): string {
     "Do not feel obligated to acknowledge every streamer line; realistic chats often drift into side chatter.",
     "SILENCE BEHAVIOR: if the streamer is silent, stay chill like a waiting room, keep it light with 'lurk' or a short on-topic question.",
     "During silence, first continue answering the last question asked, then use topic-relevant emotes/slang.",
+    "Hard ban phrases: never say 'pick a lane' or 'pick a topic'.",
+    "Do not accuse the streamer of ghosting/vanishing/disappearing after short silence; assume they are still present unless explicitly leaving.",
     "Do NOT start random food debates unless streamer silence clearly lasts over 2 minutes.",
     "React to the stream context like a real viewer with casual slang and natural chat energy.",
     "VISION INTEGRITY: only describe visuals when context.visionTags contains descriptive words.",

--- a/src/pipeline/outputParser.ts
+++ b/src/pipeline/outputParser.ts
@@ -6,12 +6,20 @@ const MAX_INFERENCE_OUTPUT_CHARS = 250_000;
 const ALLOWED_TEXT_EMOTES = new Set(["Kappa", "LUL", "PogChamp", "OMEGALUL", "monkaS", "W", "L"]);
 const UNICODE_EMOJI_PATTERN = /\p{Extended_Pictographic}/u;
 const RADIO_CHECK_BANNED_PHRASE = /\bloud and clear\b/gi;
+const REPETITION_BANNED_PHRASES = [/\bpick a lane\b/gi, /\bpick a topic\b/gi];
+const GHOSTING_BANNED_PHRASES = [/\byou (vanished|disappeared)\b/gi, /\bghosted\b/gi];
 
 function normalizeChatTextStyle(text: string): string {
   let normalized = text.toLowerCase();
   normalized = normalized.replace(/[—]/g, " ");
   normalized = normalized.replace(/\.{3,}/g, " ");
   normalized = normalized.replace(RADIO_CHECK_BANNED_PHRASE, "we hear u");
+  for (const pattern of REPETITION_BANNED_PHRASES) {
+    normalized = normalized.replace(pattern, "switch it up");
+  }
+  for (const pattern of GHOSTING_BANNED_PHRASES) {
+    normalized = normalized.replace(pattern, "still here");
+  }
   normalized = normalized.replace(/\s+/g, " ").trim();
   normalized = normalized.replace(/\.$/, "");
   return normalized;
@@ -45,6 +53,7 @@ function coerceMessage(raw: unknown): ChatMessage | null {
   const emotes = candidate.emotes.map((emote) => emote.trim()).filter((emote) => isAllowedEmote(emote));
 
   const text = normalizeChatTextStyle(candidate.text);
+  if (!text && emotes.length === 0) return null;
 
   return {
     id: typeof candidate.id === "string" ? candidate.id : `${Date.now()}-${Math.random().toString(16).slice(2)}`,

--- a/src/services/simulationOrchestrator.ts
+++ b/src/services/simulationOrchestrator.ts
@@ -37,6 +37,7 @@ export class SimulationOrchestrator {
     (meta) => this.emitMeta(meta)
   );
   private readonly transcriptSeenCounter = new Map<string, { count: number; lastSeenAt: number }>();
+  private lastNonEmptyTranscript = "";
   private recentChatHistory: string[] = [];
   private aiStatus: {
     state: "idle" | "running" | "degraded" | "error";
@@ -86,6 +87,7 @@ export class SimulationOrchestrator {
     sharedSttEngine.resume();
     sharedDeviceCapturePipeline.reset();
     this.transcriptSeenCounter.clear();
+    this.lastNonEmptyTranscript = "";
   }
 
   public cancelSidecarPull(): void {
@@ -309,7 +311,14 @@ export class SimulationOrchestrator {
 
   private applyTranscriptDecay(context: PromptPayload["context"]): PromptPayload["context"] {
     const normalized = context.transcript.trim().toLowerCase();
-    if (!normalized) return context;
+    if (!normalized) {
+      if (!this.lastNonEmptyTranscript) return context;
+      return {
+        ...context,
+        transcript: this.lastNonEmptyTranscript
+      };
+    }
+    this.lastNonEmptyTranscript = context.transcript.trim();
 
     const now = Date.now();
     for (const [key, value] of this.transcriptSeenCounter.entries()) {
@@ -322,7 +331,10 @@ export class SimulationOrchestrator {
     const seenCount = existing?.count ?? 0;
     this.transcriptSeenCounter.set(normalized, { count: seenCount + 1, lastSeenAt: now });
     if (seenCount >= 3) {
-      return { ...context, transcript: "" };
+      return {
+        ...context,
+        transcript: this.lastNonEmptyTranscript
+      };
     }
     return context;
   }

--- a/src/services/visionPollingService.ts
+++ b/src/services/visionPollingService.ts
@@ -23,6 +23,13 @@ interface VisionProviderResult {
   providerResponse: unknown;
 }
 
+const DEFAULT_OPENAI_CHAT_COMPLETIONS_ENDPOINT = "https://api.openai.com/v1/chat/completions";
+const VISION_MODEL_FALLBACKS: Record<string, string[]> = {
+  "gpt-5.4-nano-2026-03-17": ["gpt-5-mini", "gpt-4o-mini"],
+  "gpt-5-nano": ["gpt-5-mini", "gpt-4o-mini"],
+  "gpt-5-mini": ["gpt-4o-mini"]
+};
+
 export function explainVisionPollingError(reason: string): string {
   if (reason.includes("Unexpected end of JSON input")) {
     return "Vision endpoint returned truncated JSON (broken package).";
@@ -64,6 +71,18 @@ function parseVisionTagsFromText(rawText: string): string[] {
     .map((chunk) => chunk.replace(/^["'`]+|["'`]+$/g, "").trim().toLowerCase())
     .filter(Boolean)
     .slice(0, 8);
+}
+
+function visionModelCandidates(primaryModel: string): string[] {
+  const normalized = primaryModel.trim().toLowerCase();
+  const candidates = [primaryModel.trim(), ...(VISION_MODEL_FALLBACKS[normalized] ?? []), "gpt-4o-mini"];
+  return candidates.filter((candidate, index) => candidate && candidates.indexOf(candidate) === index);
+}
+
+function resolveOpenAiVisionEndpoint(config: SimulationConfig): string {
+  const endpoint = String(config.provider.cloudEndpoint ?? "").trim();
+  if (/^https:\/\/api\.openai\.com\/v1\/chat\/completions\/?$/i.test(endpoint)) return endpoint;
+  return DEFAULT_OPENAI_CHAT_COMPLETIONS_ENDPOINT;
 }
 
 export class VisionPollingService {
@@ -186,56 +205,68 @@ export class VisionPollingService {
       return { tags: normalizeVisionTags(payload), providerResponse: payload };
     }
 
-    const response = await fetch(config.provider.cloudEndpoint, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${cloudApiKey}`
-      },
-      body: JSON.stringify({
-        model: config.provider.cloudModel,
-        messages: [
-          {
-            role: "user",
-            content: [
-              {
-                type: "text",
-                text: "List what you see in 5 words."
-              },
-              {
-                type: "image_url",
-                image_url: { url: imageInput }
-              }
-            ]
-          }
-        ],
-        max_completion_tokens: 120
-      }),
-      signal: AbortSignal.timeout(Math.max(5000, Math.min(config.provider.requestTimeoutMs, 15000)))
-    });
+    const endpoint = resolveOpenAiVisionEndpoint(config);
+    let lastError: Error | null = null;
+    for (const model of visionModelCandidates(config.provider.cloudModel)) {
+      const response = await fetch(endpoint, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${cloudApiKey}`
+        },
+        body: JSON.stringify({
+          model,
+          messages: [
+            {
+              role: "user",
+              content: [
+                {
+                  type: "text",
+                  text: "List what you see in 5 words."
+                },
+                {
+                  type: "image_url",
+                  image_url: { url: imageInput }
+                }
+              ]
+            }
+          ],
+          max_completion_tokens: 120
+        }),
+        signal: AbortSignal.timeout(Math.max(5000, Math.min(config.provider.requestTimeoutMs, 15000)))
+      });
 
-    if (!response.ok) {
-      throw new Error(`OpenAI vision request failed (${response.status})`);
+      if (!response.ok) {
+        lastError = new Error(`OpenAI vision request failed (${response.status}) for model ${model}`);
+        if (response.status === 408 || response.status === 429 || response.status >= 500) continue;
+        throw lastError;
+      }
+
+      const data = (await response.json()) as {
+        choices?: Array<{ message?: { content?: string | Array<{ text?: string }> } }>;
+        output_text?: string;
+      };
+      // eslint-disable-next-line no-console
+      console.log("[VisionService] Raw response from provider:", data);
+
+      const content = data.choices?.[0]?.message?.content;
+      const text =
+        typeof content === "string"
+          ? content
+          : Array.isArray(content)
+            ? content.map((part) => part.text ?? "").join(" ")
+            : data.output_text ?? "";
+
+      const tags = parseVisionTagsFromText(text);
+      if (tags.length > 0) {
+        return {
+          providerResponse: { model, data },
+          tags
+        };
+      }
+      lastError = new Error(`OpenAI vision response for model ${model} returned no usable tags.`);
     }
 
-    const data = (await response.json()) as {
-      choices?: Array<{ message?: { content?: string | Array<{ text?: string }> } }>;
-      output_text?: string;
-    };
-    // eslint-disable-next-line no-console
-    console.log("[VisionService] Raw response from provider:", data);
-
-    const content = data.choices?.[0]?.message?.content;
-    const text =
-      typeof content === "string"
-        ? content
-        : Array.isArray(content)
-          ? content.map((part) => part.text ?? "").join(" ")
-          : data.output_text ?? "";
-
-    return {
-      providerResponse: data,
-      tags: parseVisionTagsFromText(text)
-    };
+    throw lastError ?? new Error("OpenAI vision request failed before any provider response.");
   }
 }

--- a/tests/antiEcho.test.ts
+++ b/tests/antiEcho.test.ts
@@ -192,7 +192,7 @@ describe("anti-echo constraint", () => {
     expect(diverse[1].text.toLowerCase()).not.toBe("mic check passed");
   });
 
-  it("applies transcript decay after the same transcript is seen three times", () => {
+  it("keeps transcript context stable even after repeated identical lines", () => {
     const orchestrator = makeOrchestrator();
     const baseContext = {
       transcript: "same line from streamer",
@@ -210,6 +210,6 @@ describe("anti-echo constraint", () => {
     expect(first.transcript).toBe("same line from streamer");
     expect(second.transcript).toBe("same line from streamer");
     expect(third.transcript).toBe("same line from streamer");
-    expect(fourth.transcript).toBe("");
+    expect(fourth.transcript).toBe("same line from streamer");
   });
 });

--- a/tests/captureProviders.test.ts
+++ b/tests/captureProviders.test.ts
@@ -169,6 +169,66 @@ describe("VisionPollingService", () => {
     expect(context.visionTags).toEqual(["ring light", "keyboard"]);
   });
 
+  it("falls back to gpt-4o-mini when primary OpenAI vision model is rate-limited", async () => {
+    const config = {
+      ...defaultConfig,
+      provider: { ...defaultConfig.provider, cloudEndpoint: "https://api.openai.com/v1/chat/completions", cloudModel: "gpt-5.4-nano-2026-03-17" },
+      capture: {
+        ...defaultConfig.capture,
+        visionEnabled: true,
+        useRealCapture: true,
+        visionProvider: "openai" as const,
+        visionEndpoint: "http://127.0.0.1:7778/vision-tags"
+      }
+    };
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/vision-tags")) {
+        return { ok: true, json: async () => ({ imageBase64: "abcd1234==" }) };
+      }
+      const parsed = JSON.parse(String(init?.body ?? "{}")) as { model?: string };
+      if (parsed.model === "gpt-5.4-nano-2026-03-17") {
+        return { ok: false, status: 429, json: async () => ({ error: { message: "rate limit" } }) };
+      }
+      return {
+        ok: true,
+        json: async () => ({ choices: [{ message: { content: "ring light, keyboard" } }] })
+      };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const service = new VisionPollingService(() => config, () => undefined);
+    await (service as any).tick();
+    const context = sharedDeviceCapturePipeline.getContext(config);
+    expect(context.visionTags).toEqual(["ring light", "keyboard"]);
+  });
+
+  it("forces OpenAI vision requests to OpenAI endpoint when cloud endpoint is local", async () => {
+    const config = {
+      ...defaultConfig,
+      provider: { ...defaultConfig.provider, cloudEndpoint: "http://127.0.0.1:1234/v1/chat/completions", cloudModel: "gpt-4o-mini" },
+      capture: {
+        ...defaultConfig.capture,
+        visionEnabled: true,
+        useRealCapture: true,
+        visionProvider: "openai" as const,
+        visionEndpoint: ""
+      }
+    };
+    sharedVisionFrameStore.setFrame("data:image/jpeg;base64,abcd1234==");
+
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ choices: [{ message: { content: "desk lamp, keyboard" } }] })
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const service = new VisionPollingService(() => config, () => undefined);
+    await (service as any).tick();
+    expect(String(fetchMock.mock.calls[0][0])).toBe("https://api.openai.com/v1/chat/completions");
+  });
+
   it("maps truncated JSON polling errors to a clearer warning", async () => {
     const config = {
       ...defaultConfig,

--- a/tests/hardeningFlows.test.ts
+++ b/tests/hardeningFlows.test.ts
@@ -80,12 +80,16 @@ describe("sidecar lifecycle orchestration", () => {
 
 describe("malformed json fallback + stt pause", () => {
   it("parses valid JSON object even when prefixed/suffixed with junk", () => {
-    const parsed = parseInferenceOutput(`junk before {"messages":[{"username":"u","text":"hi","emotes":[],"donationCents":null,"ttsText":null}]} junk after`);
-    expect(parsed).toHaveLength(1);
+    const parsed = parseInferenceOutput(
+      `junk before {"messages":[{"username":"u","text":"hi","emotes":[],"donationCents":null,"ttsText":null},{"username":"v","text":"yo","emotes":[],"donationCents":null,"ttsText":null}]} junk after`
+    );
+    expect(parsed).toHaveLength(2);
   });
 
   it("preserves source tags from inference payload", () => {
-    const parsed = parseInferenceOutput('{"messages":[{"username":"u","text":"hi","emotes":[],"donationCents":null,"ttsText":null,"source":"fallback-mock"}]}');
+    const parsed = parseInferenceOutput(
+      '{"messages":[{"username":"u","text":"hi","emotes":[],"donationCents":null,"ttsText":null,"source":"fallback-mock"},{"username":"v","text":"yo","emotes":[],"donationCents":null,"ttsText":null,"source":"fallback-mock"}]}'
+    );
     expect(parsed[0]?.source).toBe("fallback-mock");
   });
 

--- a/tests/pipeline.test.ts
+++ b/tests/pipeline.test.ts
@@ -74,6 +74,22 @@ describe("output parser", () => {
     );
     expect(result[0].text).toBe("we hear u we got you yes");
   });
+
+  it("sanitizes repetitive lane/topic phrasing and ghosting language", () => {
+    const result = parseInferenceOutput(
+      '{"messages":[{"text":"pick a lane you ghosted","emotes":[],"donationCents":null,"ttsText":null},{"text":"pick a topic you vanished","emotes":[],"donationCents":null,"ttsText":null}]}'
+    );
+    expect(result[0].text).toBe("switch it up you still here");
+    expect(result[1].text).toBe("switch it up still here");
+  });
+
+  it("drops fully empty messages from parsed output", () => {
+    expect(() =>
+      parseInferenceOutput(
+        '{"messages":[{"text":"","emotes":[],"donationCents":null,"ttsText":null},{"text":"ok","emotes":[],"donationCents":null,"ttsText":null}]}'
+      )
+    ).toThrow(/Expected at least 2 valid messages/);
+  });
 });
 
 


### PR DESCRIPTION
### Motivation
- Reduce UX issues where short STT pauses caused the system to treat the streamer as having "vanished" and blank out transcript context.
- Prevent repeated/viral phrasing like "pick a lane/topic" and ghosting accusations from propagating in generated chat output.
- Improve robustness of OpenAI-based vision polling when primary cloud models are rate-limited or the configured cloud endpoint is non-OpenAI.

### Description
- Preserve the last non-empty transcript in `SimulationOrchestrator` and reuse it when STT ticks are briefly empty, resetting the cache on `stop`, to avoid false "ghosting" behavior (`src/services/simulationOrchestrator.ts`).
- Harden chat normalization in `outputParser` by adding banned-pattern replacements for repetitive lane/topic phrasing and ghosting language and dropping messages that are empty in both `text` and `emotes` (`src/pipeline/outputParser.ts`).
- Add explicit guidance to the model system prompt banning the phrases `pick a lane` / `pick a topic` and discouraging premature "ghosting" accusations (`src/llm/realInferenceProvider.ts`).
- Improve OpenAI vision polling by forcing OpenAI vision calls to the official chat completions endpoint when appropriate and adding a per-model fallback chain (including `gpt-4o-mini`) with retryable-status handling and empty-tag checks (`src/services/visionPollingService.ts`).
- Add and update regression tests that cover parser sanitization, transcript persistence, and vision fallback routing (`tests/pipeline.test.ts`, `tests/antiEcho.test.ts`, `tests/captureProviders.test.ts`, `tests/hardeningFlows.test.ts`).

### Testing
- Ran the full test suite with `npm test` and all tests passed (97 tests passing).
- Exercised capture/vision tests and vision-fallback scenarios via `tests/captureProviders.test.ts` and added coverage for endpoint routing and model fallback.
- Exercised parser and anti-echo behavior with updated unit tests in `tests/pipeline.test.ts` and `tests/antiEcho.test.ts` that validate normalization and transcript continuity.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9a1df800c8324bd8243fd20c983b5)