### PR TITLE
Improve cloud/vision resilience, parser tolerance, and chat diversity rules

### DIFF
--- a/src/llm/realInferenceProvider.ts
+++ b/src/llm/realInferenceProvider.ts
@@ -207,10 +207,11 @@ function systemPromptForPayload(payload: PromptPayload): string {
     "Treat context.transcript as more important than persona flavor text when they conflict.",
     "You are simulating one live viewer reacting to the streamer in real time (not a generic standalone bot).",
     "ROLE: you are a single person in chat. Use first-person phrasing and direct 'you/bro' language to the streamer. Never say 'the chat', 'chatters', or 'the audience'.",
-    "At least 55% of messages must reference specific transcript/tone/vision details; the rest can be side-convos, memes, or crowd noise.",
+    "MIRROR BAN: never speak as if you are the streamer; react TO them, do not copy their framing.",
+    "Context grounding rule: most messages should drop 1-2 concrete keywords from transcript/tone/vision into short fragments instead of full explanations.",
 
     // Mushy middle: persona + behavior
-    "CRITICAL: never mirror the streamer's exact question text back. If streamer asks 'can you hear me?', answer directly (example: 'yep we hear u').",
+    "Never mirror the streamer's exact question text back. If streamer asks 'can you hear me?', answer directly (example: 'yep we hear u').",
     "SKIP confirmation framing: do not begin by repeating topic as a question such as 'pizza?? W' or '[topic]??'. Jump straight to reaction or joke.",
     "Do not quote the streamer's exact wording unless you are intentionally making a joke/meme about it.",
     "If transcript overlaps context.recentChatHistory heavily, treat it as the streamer reading chat; do not react to the quoted words themselves and instead react to the streamer's attitude toward chat",
@@ -224,6 +225,8 @@ function systemPromptForPayload(payload: PromptPayload): string {
     "Do not feel obligated to acknowledge every streamer line; realistic chats often drift into side chatter.",
     "SILENCE BEHAVIOR: if the streamer is silent, stay chill like a waiting room, keep it light with 'lurk' or a short on-topic question.",
     "During silence, first continue answering the last question asked, then use topic-relevant emotes/slang.",
+    "Hard ban phrases: never say 'pick a lane' or 'pick a topic'.",
+    "Do not accuse the streamer of ghosting/vanishing/disappearing after short silence; assume they are still present unless explicitly leaving.",
     "Do NOT start random food debates unless streamer silence clearly lasts over 2 minutes.",
     "React to the stream context like a real viewer with casual slang and natural chat energy.",
     "VISION INTEGRITY: only describe visuals when context.visionTags contains descriptive words.",
@@ -236,17 +239,18 @@ function systemPromptForPayload(payload: PromptPayload): string {
     "Supportive persona means kind tone, not generic praise; keep every message situational and reactive.",
 
     // Recency zone: polish + syntax
-    "Style lock: no em-dash, no ellipses, no final period, minimal capitalization, fast phone-typed fragments.",
+    "Style lock: forced lowercase, no ending punctuation, no em-dash, no ellipses, fast phone-typed fragments.",
     "Roleplay license for realism: mild profanity is allowed when it fits chat energy (ass, shit, fucked, hell nah)",
     "When vibe is critical, prefer raw wording like 'dogshit', 'ass', 'actual garbage' over sanitized filler",
     "Use rapid-fire Twitch-style pacing: at least 80% of messages must be under 4 words.",
-    "Hard syntax lock: forced lowercase, no ending punctuation, no em-dash, no ellipses.",
     "Keep most messages short fragments, meme slang, or reactions like 'w', 'l', 'lmao', 'ratio', 'wait what', 'cap', 'trippin', 'idk', 'cooked', 'bro what', 'we are so back', 'yooo', 'glazing', 'fraud', 'delusional'.",
     `Emotes rule: emotes array may contain only unicode emoji or one of [${ALLOWED_TEXT_EMOTES.join(", ")}]. Never invent emote names.`,
     "Some viewers should be emote-only (message text can be empty while emotes are populated).",
-    "Only set ttsText when donationCents is a positive number. Otherwise ttsText must be null.",
-    "DIVERSITY ANCHORS: vary sentence openers every message (examples: nah, bro, wait, yo, lowkey, fr, ngl, idk, tbh).",
-    "DIVERSITY ANCHORS: rotate message shape across the batch (question, short take, emote-only, roast, agreement).",
+    "Always include donationCents and ttsText keys. Use null for both when no donation is active.",
+    "Only set ttsText when donationCents is a positive number; otherwise ttsText must be null.",
+    "Diversity rule: vary sentence openers every message and do not repeat the same starter in nearby messages.",
+    "Starter cooldown: avoid repeating 'ngl' or 'lowkey' at the start of adjacent messages.",
+    "Diversity rule: rotate message shape across the batch (question, short take, emote-only, roast, agreement).",
     "Ignorance Clause: If streamer asks about a term you don't know, DO NOT invent a definition. React with: '??', 'who?', 'bro is yapping', or 'lmao what'.",
     "Repetition Ban: You are forbidden from using the same adjective twice in a 4-message window. Rotate slang constantly.",
     "No Explanations: NEVER drone on to explain anything. If asked a question, give a short opinion or a 1-word guess. Maybe one chatter answers seriously."
@@ -310,6 +314,10 @@ function cloudModelCandidates(model: string): string[] {
 
 function isRetryableCloudFailure(message: string): boolean {
   return /timeout|network failure|\(408\)|\(429\)|\(5\d\d\)/i.test(message);
+}
+
+function isResponseFormatSchemaFailure(status: number, detail: string): boolean {
+  return status === 400 && /invalid schema for response_format|required/i.test(detail);
 }
 
 export class HybridInferenceProvider implements InferenceProvider {
@@ -429,7 +437,7 @@ export class HybridInferenceProvider implements InferenceProvider {
 
     let lastError: Error | null = null;
     for (const model of cloudModelCandidates(config.provider.cloudModel)) {
-      const body: {
+      const baseBody: {
         model: string;
         messages: Array<{ role: "system" | "user"; content: string }>;
         response_format?: ReturnType<typeof openAiResponseSchema>;
@@ -438,38 +446,49 @@ export class HybridInferenceProvider implements InferenceProvider {
         messages
       };
       if (this.mode === "openai") {
-        body.response_format = openAiResponseSchema(payload.requestedMessageCount);
+        baseBody.response_format = openAiResponseSchema(payload.requestedMessageCount);
       }
 
-      let response: Response;
-      try {
-        response = await fetch(config.provider.cloudEndpoint, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            ...this.cloudHeaders(apiKey)
-          },
-          signal: AbortSignal.timeout(config.provider.requestTimeoutMs),
-          body: JSON.stringify(body)
-        });
-      } catch (error) {
-        const message = (error as Error).message || "request failed";
-        lastError = new Error(`Cloud provider timeout/network failure for model ${model}: ${message}`);
-        if (model === config.provider.cloudModel && isRetryableCloudFailure(lastError.message)) continue;
-        throw lastError;
-      }
+      const requestVariants =
+        this.mode === "openai"
+          ? [baseBody, { ...baseBody, response_format: undefined }]
+          : [baseBody];
 
-      if (!response.ok) {
-        const detail = await parseProviderError(response);
-        lastError = new Error(`Cloud provider failed (${response.status}) for model ${model}${detail ? `: ${detail}` : ""}`);
-        if (model === config.provider.cloudModel && isRetryableCloudFailure(lastError.message)) {
-          continue;
+      for (let variantIdx = 0; variantIdx < requestVariants.length; variantIdx += 1) {
+        const body = requestVariants[variantIdx];
+        let response: Response;
+        try {
+          response = await fetch(config.provider.cloudEndpoint, {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              ...this.cloudHeaders(apiKey)
+            },
+            signal: AbortSignal.timeout(config.provider.requestTimeoutMs),
+            body: JSON.stringify(body)
+          });
+        } catch (error) {
+          const message = (error as Error).message || "request failed";
+          lastError = new Error(`Cloud provider timeout/network failure for model ${model}: ${message}`);
+          if (model === config.provider.cloudModel && isRetryableCloudFailure(lastError.message)) break;
+          throw lastError;
         }
-        throw lastError;
-      }
 
-      const data = (await response.json()) as ProviderResponseShape;
-      return extractProviderTextOrThrow(data, `${this.mode}:${model}`);
+        if (!response.ok) {
+          const detail = await parseProviderError(response);
+          if (variantIdx === 0 && isResponseFormatSchemaFailure(response.status, detail)) {
+            continue;
+          }
+          lastError = new Error(`Cloud provider failed (${response.status}) for model ${model}${detail ? `: ${detail}` : ""}`);
+          if (model === config.provider.cloudModel && isRetryableCloudFailure(lastError.message)) {
+            break;
+          }
+          throw lastError;
+        }
+
+        const data = (await response.json()) as ProviderResponseShape;
+        return extractProviderTextOrThrow(data, `${this.mode}:${model}`);
+      }
     }
 
     throw lastError ?? new Error("Cloud provider failed before receiving a response.");

--- a/src/pipeline/outputParser.ts
+++ b/src/pipeline/outputParser.ts
@@ -6,12 +6,20 @@ const MAX_INFERENCE_OUTPUT_CHARS = 250_000;
 const ALLOWED_TEXT_EMOTES = new Set(["Kappa", "LUL", "PogChamp", "OMEGALUL", "monkaS", "W", "L"]);
 const UNICODE_EMOJI_PATTERN = /\p{Extended_Pictographic}/u;
 const RADIO_CHECK_BANNED_PHRASE = /\bloud and clear\b/gi;
+const REPETITION_BANNED_PHRASES = [/\bpick a lane\b/gi, /\bpick a topic\b/gi];
+const GHOSTING_BANNED_PHRASES = [/\byou (vanished|disappeared)\b/gi, /\bghosted\b/gi];
 
 function normalizeChatTextStyle(text: string): string {
   let normalized = text.toLowerCase();
   normalized = normalized.replace(/[—]/g, " ");
   normalized = normalized.replace(/\.{3,}/g, " ");
   normalized = normalized.replace(RADIO_CHECK_BANNED_PHRASE, "we hear u");
+  for (const pattern of REPETITION_BANNED_PHRASES) {
+    normalized = normalized.replace(pattern, "switch it up");
+  }
+  for (const pattern of GHOSTING_BANNED_PHRASES) {
+    normalized = normalized.replace(pattern, "still here");
+  }
   normalized = normalized.replace(/\s+/g, " ").trim();
   normalized = normalized.replace(/\.$/, "");
   return normalized;
@@ -23,6 +31,7 @@ function isAllowedEmote(value: string): boolean {
 }
 
 function normalizeTtsText(candidate: Record<string, unknown>, donationCents: number | null): string | undefined {
+  if (!Object.prototype.hasOwnProperty.call(candidate, "ttsText")) return undefined;
   if (candidate.ttsText === null) return undefined;
   if (typeof candidate.ttsText !== "string") return undefined;
   const trimmed = candidate.ttsText.trim();
@@ -36,15 +45,19 @@ function coerceMessage(raw: unknown): ChatMessage | null {
 
   if (typeof candidate.text !== "string") return null;
   if (!Array.isArray(candidate.emotes) || !candidate.emotes.every((item) => typeof item === "string")) return null;
-  if (!Object.prototype.hasOwnProperty.call(candidate, "donationCents")) return null;
-  if (!Object.prototype.hasOwnProperty.call(candidate, "ttsText")) return null;
-  if (!(candidate.donationCents === null || typeof candidate.donationCents === "number")) return null;
-  if (!(candidate.ttsText === null || typeof candidate.ttsText === "string")) return null;
+  if (
+    Object.prototype.hasOwnProperty.call(candidate, "donationCents") &&
+    !(candidate.donationCents === null || typeof candidate.donationCents === "number")
+  ) {
+    return null;
+  }
+  if (Object.prototype.hasOwnProperty.call(candidate, "ttsText") && !(candidate.ttsText === null || typeof candidate.ttsText === "string")) return null;
 
   const donationCents = typeof candidate.donationCents === "number" && candidate.donationCents > 0 ? Math.floor(candidate.donationCents) : null;
   const emotes = candidate.emotes.map((emote) => emote.trim()).filter((emote) => isAllowedEmote(emote));
 
   const text = normalizeChatTextStyle(candidate.text);
+  if (!text && emotes.length === 0) return null;
 
   return {
     id: typeof candidate.id === "string" ? candidate.id : `${Date.now()}-${Math.random().toString(16).slice(2)}`,

--- a/src/services/simulationOrchestrator.ts
+++ b/src/services/simulationOrchestrator.ts
@@ -37,6 +37,7 @@ export class SimulationOrchestrator {
     (meta) => this.emitMeta(meta)
   );
   private readonly transcriptSeenCounter = new Map<string, { count: number; lastSeenAt: number }>();
+  private lastNonEmptyTranscript = "";
   private recentChatHistory: string[] = [];
   private aiStatus: {
     state: "idle" | "running" | "degraded" | "error";
@@ -86,6 +87,7 @@ export class SimulationOrchestrator {
     sharedSttEngine.resume();
     sharedDeviceCapturePipeline.reset();
     this.transcriptSeenCounter.clear();
+    this.lastNonEmptyTranscript = "";
   }
 
   public cancelSidecarPull(): void {
@@ -239,6 +241,8 @@ export class SimulationOrchestrator {
       bannedPhrases.forEach((pattern) => {
         next = next.replace(pattern, "we");
       });
+      next = next.replace(/^\s*we\s+(are|re|r)\s+/i, "you ");
+      next = next.replace(/^\s*we\s+/i, "you ");
       next = next.replace(/[!?.,;:)\]]+$/g, "");
       next = next.replace(/\s+/g, " ").trim();
       return next;
@@ -247,9 +251,10 @@ export class SimulationOrchestrator {
   }
 
   private enforceDiversityRules(messages: ChatMessage[], behavioralModes: string[]): ChatMessage[] {
-    const slangCooldownWords = ["lowkey", "bet", "cooked", "fr"];
+    const slangCooldownWords = ["lowkey", "ngl", "bet", "cooked", "fr"];
     const slangAlternatives: Record<string, string[]> = {
       lowkey: ["ngl", "tbh", "honestly"],
+      ngl: ["lowkey", "tbh", "fr"],
       bet: ["aight", "say less", "ok then"],
       cooked: ["chalked", "donezo", "gg"],
       fr: ["facts", "real", "deadass"]
@@ -272,21 +277,38 @@ export class SimulationOrchestrator {
       return { ...message, text };
     });
 
-    if (remapped.length < 2) return remapped;
+    const starterAlternatives: Record<string, string[]> = {
+      lowkey: ["tbh", "idk", "fr"],
+      ngl: ["lowkey", "idk", "tbh"]
+    };
+    const starterSeen = new Set<string>();
+    const withStarterDiversity = remapped.map((message, index) => {
+      const words = message.text.trim().split(/\s+/);
+      const starter = (words[0] ?? "").toLowerCase();
+      if (starterAlternatives[starter] && starterSeen.has(starter)) {
+        const alternatives = starterAlternatives[starter];
+        words[0] = alternatives[index % alternatives.length];
+        return { ...message, text: words.join(" ").trim() };
+      }
+      if (starter) starterSeen.add(starter);
+      return message;
+    });
+
+    if (withStarterDiversity.length < 2) return withStarterDiversity;
 
     if (behavioralModes.includes("thirst")) {
-      remapped[0] = { ...remapped[0], text: "gyatt respectfully 😳" };
-      remapped[1] = { ...remapped[1], text: "simps in chat stand up" };
-      return remapped;
+      withStarterDiversity[0] = { ...withStarterDiversity[0], text: "gyatt respectfully 😳" };
+      withStarterDiversity[1] = { ...withStarterDiversity[1], text: "simps in chat stand up" };
+      return withStarterDiversity;
     }
 
     const supportiveSignal = /\b(yes|yup|we hear u|w audio|mic w|facts|same|true|good)\b/i;
-    if (supportiveSignal.test(remapped[0].text) && supportiveSignal.test(remapped[1].text)) {
+    if (supportiveSignal.test(withStarterDiversity[0].text) && supportiveSignal.test(withStarterDiversity[1].text)) {
       const contrastReplies = ["nah chat trolling today", "bro that take is wild", "off topic but who ate my snacks", "skill issue detected 🤨"];
-      remapped[1] = { ...remapped[1], text: contrastReplies[Math.floor(Math.random() * contrastReplies.length)] };
+      withStarterDiversity[1] = { ...withStarterDiversity[1], text: contrastReplies[Math.floor(Math.random() * contrastReplies.length)] };
     }
 
-    const deduped = remapped.map((message) => ({ ...message }));
+    const deduped = withStarterDiversity.map((message) => ({ ...message }));
     const seen = new Set<string>();
     const fallbackReplies = [
       "new take pls",
@@ -304,12 +326,37 @@ export class SimulationOrchestrator {
       seen.add(key);
     });
 
+    const maxWords = 4;
+    const minimumShortRatio = 0.8;
+    const countWords = (text: string) => text.trim().split(/\s+/).filter(Boolean).length;
+    const shorten = (text: string) => text.trim().split(/\s+/).slice(0, maxWords).join(" ");
+    const requiredShort = Math.ceil(deduped.length * minimumShortRatio);
+    let shortCount = deduped.filter((message) => countWords(message.text) <= maxWords).length;
+    if (shortCount < requiredShort) {
+      const longIndices = deduped
+        .map((message, index) => ({ index, words: countWords(message.text) }))
+        .filter((entry) => entry.words > maxWords)
+        .sort((a, b) => b.words - a.words);
+      for (const entry of longIndices) {
+        if (shortCount >= requiredShort) break;
+        deduped[entry.index].text = shorten(deduped[entry.index].text);
+        shortCount += 1;
+      }
+    }
+
     return deduped;
   }
 
   private applyTranscriptDecay(context: PromptPayload["context"]): PromptPayload["context"] {
     const normalized = context.transcript.trim().toLowerCase();
-    if (!normalized) return context;
+    if (!normalized) {
+      if (!this.lastNonEmptyTranscript) return context;
+      return {
+        ...context,
+        transcript: this.lastNonEmptyTranscript
+      };
+    }
+    this.lastNonEmptyTranscript = context.transcript.trim();
 
     const now = Date.now();
     for (const [key, value] of this.transcriptSeenCounter.entries()) {
@@ -322,7 +369,10 @@ export class SimulationOrchestrator {
     const seenCount = existing?.count ?? 0;
     this.transcriptSeenCounter.set(normalized, { count: seenCount + 1, lastSeenAt: now });
     if (seenCount >= 3) {
-      return { ...context, transcript: "" };
+      return {
+        ...context,
+        transcript: this.lastNonEmptyTranscript
+      };
     }
     return context;
   }

--- a/src/services/visionPollingService.ts
+++ b/src/services/visionPollingService.ts
@@ -21,7 +21,16 @@ interface VisionEndpointPayload {
 interface VisionProviderResult {
   tags: string[];
   providerResponse: unknown;
+  rawText?: string;
+  model?: string;
 }
+
+const DEFAULT_OPENAI_CHAT_COMPLETIONS_ENDPOINT = "https://api.openai.com/v1/chat/completions";
+const VISION_MODEL_FALLBACKS: Record<string, string[]> = {
+  "gpt-5.4-nano-2026-03-17": ["gpt-5-mini", "gpt-4o-mini"],
+  "gpt-5-nano": ["gpt-5-mini", "gpt-4o-mini"],
+  "gpt-5-mini": ["gpt-4o-mini"]
+};
 
 export function explainVisionPollingError(reason: string): string {
   if (reason.includes("Unexpected end of JSON input")) {
@@ -64,6 +73,53 @@ function parseVisionTagsFromText(rawText: string): string[] {
     .map((chunk) => chunk.replace(/^["'`]+|["'`]+$/g, "").trim().toLowerCase())
     .filter(Boolean)
     .slice(0, 8);
+}
+
+function tryParseJsonTags(rawText: string): string[] {
+  const trimmed = rawText.trim();
+  if (!trimmed) return [];
+  try {
+    const parsed = JSON.parse(trimmed) as { tags?: unknown };
+    if (!Array.isArray(parsed.tags)) return [];
+    return parsed.tags
+      .filter((tag): tag is string => typeof tag === "string")
+      .map((tag) => tag.trim().toLowerCase())
+      .filter(Boolean)
+      .slice(0, 8);
+  } catch {
+    return [];
+  }
+}
+
+function extractVisionText(data: {
+  choices?: Array<{ message?: { content?: string | Array<{ text?: string | { value?: string } }> } }>;
+  output_text?: string;
+}): string {
+  const content = data.choices?.[0]?.message?.content;
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((part) => {
+        if (typeof part?.text === "string") return part.text;
+        if (part?.text && typeof part.text === "object" && typeof part.text.value === "string") return part.text.value;
+        return "";
+      })
+      .join(" ")
+      .trim();
+  }
+  return data.output_text ?? "";
+}
+
+function visionModelCandidates(primaryModel: string): string[] {
+  const normalized = primaryModel.trim().toLowerCase();
+  const candidates = [primaryModel.trim(), ...(VISION_MODEL_FALLBACKS[normalized] ?? []), "gpt-4o-mini"];
+  return candidates.filter((candidate, index) => candidate && candidates.indexOf(candidate) === index);
+}
+
+function resolveOpenAiVisionEndpoint(config: SimulationConfig): string {
+  const endpoint = String(config.provider.cloudEndpoint ?? "").trim();
+  if (/^https:\/\/api\.openai\.com\/v1\/chat\/completions\/?$/i.test(endpoint)) return endpoint;
+  return DEFAULT_OPENAI_CHAT_COMPLETIONS_ENDPOINT;
 }
 
 export class VisionPollingService {
@@ -148,6 +204,19 @@ export class VisionPollingService {
 
       if (tags.length) {
         sharedDeviceCapturePipeline.ingestVisionSample({ tags });
+      } else {
+        this.emitMeta({
+          warnings: [
+            `Vision provider returned empty tags${providerResult.model ? ` (model=${providerResult.model})` : ""}. Check providerResponse/rawText in metadata for diagnosis.`
+          ],
+          vision: {
+            provider: config.capture.visionProvider,
+            endpoint: config.capture.visionEndpoint,
+            rawText: providerResult.rawText ?? "",
+            providerResponse: providerResult.providerResponse,
+            tags
+          }
+        });
       }
 
       // eslint-disable-next-line no-console
@@ -186,56 +255,70 @@ export class VisionPollingService {
       return { tags: normalizeVisionTags(payload), providerResponse: payload };
     }
 
-    const response = await fetch(config.provider.cloudEndpoint, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${cloudApiKey}`
-      },
-      body: JSON.stringify({
-        model: config.provider.cloudModel,
-        messages: [
-          {
-            role: "user",
-            content: [
-              {
-                type: "text",
-                text: "List what you see in 5 words."
-              },
-              {
-                type: "image_url",
-                image_url: { url: imageInput }
-              }
-            ]
-          }
-        ],
-        max_completion_tokens: 120
-      }),
-      signal: AbortSignal.timeout(Math.max(5000, Math.min(config.provider.requestTimeoutMs, 15000)))
-    });
+    const endpoint = resolveOpenAiVisionEndpoint(config);
+    let lastError: Error | null = null;
+    let lastEmptyResult: VisionProviderResult | null = null;
+    for (const model of visionModelCandidates(config.provider.cloudModel)) {
+      const response = await fetch(endpoint, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${cloudApiKey}`
+        },
+        body: JSON.stringify({
+          model,
+          messages: [
+            {
+              role: "user",
+              content: [
+                {
+                  type: "text",
+                  text: 'Return strict JSON: {"tags":["tag1","tag2","tag3"]}. Keep tags short concrete nouns/adjectives from the frame.'
+                },
+                {
+                  type: "image_url",
+                  image_url: { url: imageInput }
+                }
+              ]
+            }
+          ],
+          max_completion_tokens: 120
+        }),
+        signal: AbortSignal.timeout(Math.max(5000, Math.min(config.provider.requestTimeoutMs, 15000)))
+      });
 
-    if (!response.ok) {
-      throw new Error(`OpenAI vision request failed (${response.status})`);
+      if (!response.ok) {
+        lastError = new Error(`OpenAI vision request failed (${response.status}) for model ${model}`);
+        if (response.status === 408 || response.status === 429 || response.status >= 500) continue;
+        throw lastError;
+      }
+
+      const data = (await response.json()) as {
+        choices?: Array<{ message?: { content?: string | Array<{ text?: string }> } }>;
+        output_text?: string;
+      };
+      // eslint-disable-next-line no-console
+      console.log("[VisionService] Raw response from provider:", data);
+
+      const text = extractVisionText(data);
+      const tags = tryParseJsonTags(text).length ? tryParseJsonTags(text) : parseVisionTagsFromText(text);
+      if (tags.length > 0) {
+        return {
+          providerResponse: { model, data },
+          tags,
+          rawText: text,
+          model
+        };
+      }
+      lastEmptyResult = {
+        providerResponse: { model, data },
+        tags: [],
+        rawText: text,
+        model
+      };
     }
 
-    const data = (await response.json()) as {
-      choices?: Array<{ message?: { content?: string | Array<{ text?: string }> } }>;
-      output_text?: string;
-    };
-    // eslint-disable-next-line no-console
-    console.log("[VisionService] Raw response from provider:", data);
-
-    const content = data.choices?.[0]?.message?.content;
-    const text =
-      typeof content === "string"
-        ? content
-        : Array.isArray(content)
-          ? content.map((part) => part.text ?? "").join(" ")
-          : data.output_text ?? "";
-
-    return {
-      providerResponse: data,
-      tags: parseVisionTagsFromText(text)
-    };
+    if (lastEmptyResult) return lastEmptyResult;
+    throw lastError ?? new Error("OpenAI vision request failed before any provider response.");
   }
 }

--- a/tests/antiEcho.test.ts
+++ b/tests/antiEcho.test.ts
@@ -192,7 +192,39 @@ describe("anti-echo constraint", () => {
     expect(diverse[1].text.toLowerCase()).not.toBe("mic check passed");
   });
 
-  it("applies transcript decay after the same transcript is seen three times", () => {
+  it("prevents viewer messages from mirroring streamer-style leading 'we' phrasing", () => {
+    const orchestrator = makeOrchestrator();
+    const input: ChatMessage[] = [
+      {
+        id: "1",
+        username: "user1",
+        text: "We are live now",
+        emotes: [],
+        donationCents: null,
+        ttsText: null,
+        createdAt: new Date().toISOString()
+      }
+    ];
+    const normalized = (orchestrator as any).enforcePersonaSyntax(input);
+    expect(normalized[0].text).toBe("you live now");
+  });
+
+  it("enforces starter diversity and brevity ratio across batches", () => {
+    const orchestrator = makeOrchestrator();
+    const input: ChatMessage[] = [
+      { id: "1", username: "u1", text: "ngl this is kinda too long for chat pace", emotes: [], donationCents: null, ttsText: null, createdAt: new Date().toISOString() },
+      { id: "2", username: "u2", text: "ngl we are still talking way too much here", emotes: [], donationCents: null, ttsText: null, createdAt: new Date().toISOString() },
+      { id: "3", username: "u3", text: "lowkey another sentence that should be shorter", emotes: [], donationCents: null, ttsText: null, createdAt: new Date().toISOString() },
+      { id: "4", username: "u4", text: "lowkey one more heavy sentence for test", emotes: [], donationCents: null, ttsText: null, createdAt: new Date().toISOString() },
+      { id: "5", username: "u5", text: "bro this one stays long too", emotes: [], donationCents: null, ttsText: null, createdAt: new Date().toISOString() }
+    ];
+    const diverse = (orchestrator as any).enforceDiversityRules(input, ["default"]);
+    expect(diverse[1].text.split(/\s+/)[0]).not.toBe("ngl");
+    const shortCount = diverse.filter((message: ChatMessage) => message.text.trim().split(/\s+/).length <= 4).length;
+    expect(shortCount).toBeGreaterThanOrEqual(4);
+  });
+
+  it("keeps transcript context stable even after repeated identical lines", () => {
     const orchestrator = makeOrchestrator();
     const baseContext = {
       transcript: "same line from streamer",
@@ -210,6 +242,6 @@ describe("anti-echo constraint", () => {
     expect(first.transcript).toBe("same line from streamer");
     expect(second.transcript).toBe("same line from streamer");
     expect(third.transcript).toBe("same line from streamer");
-    expect(fourth.transcript).toBe("");
+    expect(fourth.transcript).toBe("same line from streamer");
   });
 });

--- a/tests/captureProviders.test.ts
+++ b/tests/captureProviders.test.ts
@@ -141,6 +141,40 @@ describe("VisionPollingService", () => {
     expect(context.visionTags).toEqual(["green hoodie", "gaming headset", "ring light"]);
   });
 
+  it("parses JSON-tagged OpenAI vision responses", async () => {
+    const config = {
+      ...defaultConfig,
+      provider: { ...defaultConfig.provider, cloudEndpoint: "https://api.openai.com/v1/chat/completions", cloudModel: "gpt-4o-mini" },
+      capture: {
+        ...defaultConfig.capture,
+        visionEnabled: true,
+        useRealCapture: true,
+        visionProvider: "openai" as const,
+        visionEndpoint: "http://127.0.0.1:7778/vision-tags"
+      }
+    };
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/vision-tags")) {
+        return {
+          ok: true,
+          json: async () => ({ imageBase64: "abcd1234==" })
+        };
+      }
+      return {
+        ok: true,
+        json: async () => ({ choices: [{ message: { content: '{"tags":["ring light","keyboard"]}' } }] })
+      };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const service = new VisionPollingService(() => config, () => undefined);
+    await (service as any).tick();
+    const context = sharedDeviceCapturePipeline.getContext(config);
+    expect(context.visionTags).toEqual(["ring light", "keyboard"]);
+  });
+
   it("uses live-monitor uploaded frame for OpenAI provider when vision endpoint is blank", async () => {
     const config = {
       ...defaultConfig,
@@ -167,6 +201,96 @@ describe("VisionPollingService", () => {
     await (service as any).tick();
     const context = sharedDeviceCapturePipeline.getContext(config);
     expect(context.visionTags).toEqual(["ring light", "keyboard"]);
+  });
+
+  it("falls back to gpt-4o-mini when primary OpenAI vision model is rate-limited", async () => {
+    const config = {
+      ...defaultConfig,
+      provider: { ...defaultConfig.provider, cloudEndpoint: "https://api.openai.com/v1/chat/completions", cloudModel: "gpt-5.4-nano-2026-03-17" },
+      capture: {
+        ...defaultConfig.capture,
+        visionEnabled: true,
+        useRealCapture: true,
+        visionProvider: "openai" as const,
+        visionEndpoint: "http://127.0.0.1:7778/vision-tags"
+      }
+    };
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/vision-tags")) {
+        return { ok: true, json: async () => ({ imageBase64: "abcd1234==" }) };
+      }
+      const parsed = JSON.parse(String(init?.body ?? "{}")) as { model?: string };
+      if (parsed.model === "gpt-5.4-nano-2026-03-17") {
+        return { ok: false, status: 429, json: async () => ({ error: { message: "rate limit" } }) };
+      }
+      return {
+        ok: true,
+        json: async () => ({ choices: [{ message: { content: "ring light, keyboard" } }] })
+      };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const service = new VisionPollingService(() => config, () => undefined);
+    await (service as any).tick();
+    const context = sharedDeviceCapturePipeline.getContext(config);
+    expect(context.visionTags).toEqual(["ring light", "keyboard"]);
+  });
+
+  it("forces OpenAI vision requests to OpenAI endpoint when cloud endpoint is local", async () => {
+    const config = {
+      ...defaultConfig,
+      provider: { ...defaultConfig.provider, cloudEndpoint: "http://127.0.0.1:1234/v1/chat/completions", cloudModel: "gpt-4o-mini" },
+      capture: {
+        ...defaultConfig.capture,
+        visionEnabled: true,
+        useRealCapture: true,
+        visionProvider: "openai" as const,
+        visionEndpoint: ""
+      }
+    };
+    sharedVisionFrameStore.setFrame("data:image/jpeg;base64,abcd1234==");
+
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ choices: [{ message: { content: "desk lamp, keyboard" } }] })
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const service = new VisionPollingService(() => config, () => undefined);
+    await (service as any).tick();
+    expect(String(fetchMock.mock.calls[0][0])).toBe("https://api.openai.com/v1/chat/completions");
+  });
+
+  it("emits warning metadata when provider responds but produces empty tags", async () => {
+    const config = {
+      ...defaultConfig,
+      provider: { ...defaultConfig.provider, cloudEndpoint: "https://api.openai.com/v1/chat/completions", cloudModel: "gpt-4o-mini" },
+      capture: {
+        ...defaultConfig.capture,
+        visionEnabled: true,
+        useRealCapture: true,
+        visionProvider: "openai" as const,
+        visionEndpoint: ""
+      }
+    };
+    sharedVisionFrameStore.setFrame("data:image/jpeg;base64,abcd1234==");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ choices: [{ message: { content: "" } }] })
+      }))
+    );
+    const emitMeta = vi.fn();
+    const service = new VisionPollingService(() => config, emitMeta);
+    await (service as any).tick();
+    expect(emitMeta).toHaveBeenCalledWith(
+      expect.objectContaining({
+        warnings: expect.arrayContaining([expect.stringContaining("Vision provider returned empty tags")])
+      })
+    );
   });
 
   it("maps truncated JSON polling errors to a clearer warning", async () => {

--- a/tests/hardeningFlows.test.ts
+++ b/tests/hardeningFlows.test.ts
@@ -80,12 +80,16 @@ describe("sidecar lifecycle orchestration", () => {
 
 describe("malformed json fallback + stt pause", () => {
   it("parses valid JSON object even when prefixed/suffixed with junk", () => {
-    const parsed = parseInferenceOutput(`junk before {"messages":[{"username":"u","text":"hi","emotes":[],"donationCents":null,"ttsText":null}]} junk after`);
-    expect(parsed).toHaveLength(1);
+    const parsed = parseInferenceOutput(
+      `junk before {"messages":[{"username":"u","text":"hi","emotes":[],"donationCents":null,"ttsText":null},{"username":"v","text":"yo","emotes":[],"donationCents":null,"ttsText":null}]} junk after`
+    );
+    expect(parsed).toHaveLength(2);
   });
 
   it("preserves source tags from inference payload", () => {
-    const parsed = parseInferenceOutput('{"messages":[{"username":"u","text":"hi","emotes":[],"donationCents":null,"ttsText":null,"source":"fallback-mock"}]}');
+    const parsed = parseInferenceOutput(
+      '{"messages":[{"username":"u","text":"hi","emotes":[],"donationCents":null,"ttsText":null,"source":"fallback-mock"},{"username":"v","text":"yo","emotes":[],"donationCents":null,"ttsText":null,"source":"fallback-mock"}]}'
+    );
     expect(parsed[0]?.source).toBe("fallback-mock");
   });
 

--- a/tests/integrationRouting.test.ts
+++ b/tests/integrationRouting.test.ts
@@ -387,6 +387,58 @@ describe("hybrid routing and failover", () => {
     await server.close();
   });
 
+  it("retries once without response_format when strict schema is rejected", async () => {
+    process.env.STREAMSIM_CLOUD_API_KEY = "abc123";
+    const bodies: Array<Record<string, unknown>> = [];
+    const server = await withTestServer((req, res) => {
+      if (req.method !== "POST") {
+        res.writeHead(404);
+        res.end();
+        return;
+      }
+
+      let body = "";
+      req.on("data", (chunk: Buffer) => (body += chunk.toString("utf8")));
+      req.on("end", () => {
+        const parsed = JSON.parse(body) as Record<string, unknown>;
+        bodies.push(parsed);
+        if (bodies.length === 1) {
+          res.writeHead(400, { "Content-Type": "application/json" });
+          res.end(
+            JSON.stringify({
+              error: {
+                message:
+                  "Invalid schema for response_format 'streamsim_chat_batch': required must include every property key"
+              }
+            })
+          );
+          return;
+        }
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ choices: [{ message: { content: '{"messages":[]}' } }] }));
+      });
+    });
+
+    const provider = new HybridInferenceProvider("openai");
+    const config = { ...defaultConfig, provider: { ...defaultConfig.provider, cloudEndpoint: server.url, cloudModel: "gpt-5.4-nano-2026-03-17", maxRetries: 0 } };
+    const payload = {
+      persona: "supportive" as const,
+      bias: "agree" as const,
+      emoteOnly: false,
+      viewerCount: 10,
+      requestedMessageCount: 1,
+      situationalTags: [],
+      behavioralModes: ["default"],
+      context: { transcript: "can you hear me?", tone: { volumeRms: 0.5, paceWpm: 140 }, visionTags: ["monitor"], recentChatHistory: [], timestamp: new Date().toISOString() }
+    };
+
+    await expect(provider.generate(payload, config)).resolves.toContain("messages");
+    expect(bodies).toHaveLength(2);
+    expect((bodies[0] as { response_format?: unknown }).response_format).toBeDefined();
+    expect((bodies[1] as { response_format?: unknown }).response_format).toBeUndefined();
+    await server.close();
+  });
+
   it("includes context.transcript and anti-generic reactive instructions in system prompt", async () => {
     process.env.STREAMSIM_CLOUD_API_KEY = "abc123";
     const server = await withTestServer((req, res) => {

--- a/tests/pipeline.test.ts
+++ b/tests/pipeline.test.ts
@@ -46,6 +46,13 @@ describe("output parser", () => {
     expect(result[0].username).toBe("");
   });
 
+  it("accepts messages when donation fields are omitted", () => {
+    const result = parseInferenceOutput('{"messages":[{"text":"hi","emotes":[]},{"text":"yo","emotes":["🔥"]}]}');
+    expect(result).toHaveLength(2);
+    expect(result[0].donationCents).toBeUndefined();
+    expect(result[0].ttsText).toBeUndefined();
+  });
+
   it("throws when no valid messages are present", () => {
     expect(() => parseInferenceOutput('{"messages":[{"foo":1}]}')).toThrow(/Expected at least 2 valid messages/);
   });
@@ -73,6 +80,22 @@ describe("output parser", () => {
       '{"messages":[{"text":"LOUD AND CLEAR... We got you—yes.","emotes":[],"donationCents":null,"ttsText":null},{"text":"second","emotes":[],"donationCents":null,"ttsText":null}]}'
     );
     expect(result[0].text).toBe("we hear u we got you yes");
+  });
+
+  it("sanitizes repetitive lane/topic phrasing and ghosting language", () => {
+    const result = parseInferenceOutput(
+      '{"messages":[{"text":"pick a lane you ghosted","emotes":[],"donationCents":null,"ttsText":null},{"text":"pick a topic you vanished","emotes":[],"donationCents":null,"ttsText":null}]}'
+    );
+    expect(result[0].text).toBe("switch it up you still here");
+    expect(result[1].text).toBe("switch it up still here");
+  });
+
+  it("drops fully empty messages from parsed output", () => {
+    expect(() =>
+      parseInferenceOutput(
+        '{"messages":[{"text":"","emotes":[],"donationCents":null,"ttsText":null},{"text":"ok","emotes":[],"donationCents":null,"ttsText":null}]}'
+      )
+    ).toThrow(/Expected at least 2 valid messages/);
   });
 });
 


### PR DESCRIPTION
### Motivation

- Harden cloud inference against strict `response_format` schema rejections and intermittent model errors to improve successful fallbacks. 
- Make vision polling more robust and transparent by better endpoint resolution, model fallbacks, and extracting/tagging logic from varied provider outputs. 
- Relax and sanitize parsed output handling and strengthen persona/diversity/transcript rules so simulated viewer messages are more realistic and safer.

### Description

- Add retry logic in cloud generation to retry once without `response_format` when the provider returns a 400 schema rejection and generalize model failover behavior in `generateCloud` (added `isResponseFormatSchemaFailure`).
- Rework vision polling in `VisionPollingService` to resolve a proper OpenAI endpoint, try model fallbacks, extract text from different response shapes, attempt JSON tag parsing before free-text parsing, and emit diagnostics when providers return empty tags. 
- Relax parsing in `outputParser` so donation/tts fields are optional, suppress empty messages, sanitize banned/ghosting phrases, normalize chat style, and preserve proper `ttsText` only when donations exist. 
- Update `SimulationOrchestrator` behavior: keep a `lastNonEmptyTranscript` to avoid dropping context on repeated lines, transform leading "we" phrasing into direct `you` persona phrasing, and enhance diversity rules to include starter cooldowns and brevity enforcement. 
- Updated and added tests to cover these behaviors and edge cases across parsing, vision polling, orchestration diversity, and cloud routing.

### Testing

- Updated and added unit/integration tests in `tests/*` (notably `antiEcho.test.ts`, `captureProviders.test.ts`, `hardeningFlows.test.ts`, `integrationRouting.test.ts`, and `pipeline.test.ts`) to cover vision JSON parsing, OpenAI model fallbacks, response_format retry, parser tolerance, persona syntax, and diversity/brevity enforcement. 
- Ran the test suite with `npm test` and verified the updated tests execute; all tests passed. 
- Exercised cloud/vision code paths in tests that simulate provider responses including 400 schema rejections, 429 rate-limits, empty vision content, and valid JSON-tagged vision replies.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9a1df800c8324bd8243fd20c983b5)