### PR TITLE
Expose latest vision tag metadata in diagnostics and add status auto-refresh to UI

### DIFF
--- a/src/capture/deviceCapturePipeline.ts
+++ b/src/capture/deviceCapturePipeline.ts
@@ -94,11 +94,13 @@ export class DeviceCapturePipeline {
     this.lastIntelligenceSample = null;
   }
 
-  public diagnostics(): { micPaused: boolean; bufferedFrames: number; hasVisionSample: boolean } {
+  public diagnostics(): { micPaused: boolean; bufferedFrames: number; hasVisionSample: boolean; latestVisionTagCount: number; latestVisionCapturedAt: number | null } {
     return {
       micPaused: this.micPaused,
       bufferedFrames: this.micFrames.length,
-      hasVisionSample: Boolean(this.lastVisionSample)
+      hasVisionSample: Boolean(this.lastVisionSample),
+      latestVisionTagCount: this.lastVisionSample?.tags.length ?? 0,
+      latestVisionCapturedAt: this.lastVisionSample?.capturedAt ?? null
     };
   }
 

--- a/src/public/app.js
+++ b/src/public/app.js
@@ -35,6 +35,7 @@ let micCheckProbeInFlight = false;
 let latestCaptionText = "";
 let latestStatusPayload = null;
 let simulationActionInFlight = false;
+let statusAutoRefreshInterval = null;
 let latestDeviceVerification = {
   micPermission: false,
   cameraPermission: false,
@@ -49,6 +50,7 @@ const MIC_CHECK_BUFFER_SECONDS = 8;
 const MIC_CHECK_MIN_SAMPLES = 12000;
 const CAMERA_FRAME_CONFIRM_TIMEOUT_MS = 3000;
 const LIVE_MONITOR_VISION_SAMPLE_MS = 8000;
+const STATUS_AUTO_REFRESH_MS = 5000;
 const STT_DEFAULT_ENDPOINTS = {
   "local-whisper": "http://127.0.0.1:7778/stt",
   whispercpp: "http://127.0.0.1:7778/stt",
@@ -700,6 +702,7 @@ function summarizeVisionHealth(payload) {
   const useRealCapture = Boolean(capture.useRealCapture);
   const endpoint = capture.visionEndpoint ?? "n/a";
   const hasVisionSample = Boolean(payload.privacy?.captureBuffer?.hasVisionSample);
+  const latestVisionTagCount = Number(payload.privacy?.captureBuffer?.latestVisionTagCount ?? 0);
   const hasCloudKey = Boolean(payload.secrets?.hasCloudKey);
 
   let ready = true;
@@ -718,12 +721,16 @@ function summarizeVisionHealth(payload) {
 
   const sampleStatus = enabled
     ? hasVisionSample
-      ? "latest sample present"
+      ? latestVisionTagCount > 0
+        ? "latest sample present"
+        : "sample present, awaiting tag extraction"
       : "waiting for first sample"
     : "not collecting";
   const detailWithHint = sampleStatus === "waiting for first sample" && enabled && useRealCapture
     ? `${detail}; run Start Simulation and confirm the vision endpoint is producing tags (webcam permission alone does not populate visionTags).`
-    : detail;
+    : sampleStatus === "sample present, awaiting tag extraction"
+      ? `${detail}; camera frames are arriving but provider parsing returned no tags yet. Check meta warnings/providerResponse/rawText for diagnosis.`
+      : detail;
 
   visionHealthSummary.textContent = [
     `Vision enabled: ${enabled ? "yes" : "no"}`,
@@ -1237,6 +1244,7 @@ liveMonitorEnabled?.addEventListener("change", async () => {
 window.addEventListener("beforeunload", () => {
   stopLiveMonitor();
   stopMicVerificationCheck();
+  if (statusAutoRefreshInterval) clearInterval(statusAutoRefreshInterval);
 });
 
 const events = new EventSource("/api/events");
@@ -1308,6 +1316,12 @@ async function boot() {
   setCaptionPreview("No speech captured yet.");
   setCaptionStatus("Run Verify Microphone to start mic/STT check.", "warn");
   ensureVerifyCameraButtonActive();
+  if (statusAutoRefreshInterval) clearInterval(statusAutoRefreshInterval);
+  statusAutoRefreshInterval = setInterval(() => {
+    refreshStatus().catch(() => {
+      /* ignore transient polling errors; next interval retries */
+    });
+  }, STATUS_AUTO_REFRESH_MS);
 }
 
 void boot();


### PR DESCRIPTION
### Motivation
- Improve visibility into vision capture health by surfacing tag counts and capture timestamps in diagnostics to better distinguish between "no sample" and "sample present but no tags yet" states.
- Keep the status/dashboard UI up-to-date by adding a periodic status refresh so runtime state (vision, STT, device verification) reflects recent changes without manual reload.

### Description
- Extend `DeviceCapturePipeline.diagnostics()` to include `latestVisionTagCount` and `latestVisionCapturedAt` so callers can inspect recent vision metadata.
- Update `summarizeVisionHealth()` in `src/public/app.js` to read `latestVisionTagCount` and report a more granular sample state: "sample present, awaiting tag extraction" when frames arrive but there are no tags yet, with a helpful diagnostic hint in the detail text.
- Add `statusAutoRefreshInterval` and `STATUS_AUTO_REFRESH_MS` and start a polling interval in `boot()` that calls `refreshStatus()` every 5s, with the interval cleared on `beforeunload` and reset on boot to avoid duplicate timers.
- Use optional chaining and safe conversions when reading the new payload fields.

### Testing
- Ran the project's test suite (`npm test`) and linters (`npm run lint`), and they completed successfully.
- Performed a front-end build (`npm run build`) which succeeded to ensure the UI changes compile.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9bd5cffa08324b012de246ddf45ed)