### PR TITLE
Add OpenAI vision fallback, capture diagnostics, and UI status auto-refresh

### DIFF
--- a/src/capture/deviceCapturePipeline.ts
+++ b/src/capture/deviceCapturePipeline.ts
@@ -94,11 +94,13 @@ export class DeviceCapturePipeline {
     this.lastIntelligenceSample = null;
   }
 
-  public diagnostics(): { micPaused: boolean; bufferedFrames: number; hasVisionSample: boolean } {
+  public diagnostics(): { micPaused: boolean; bufferedFrames: number; hasVisionSample: boolean; latestVisionTagCount: number; latestVisionCapturedAt: number | null } {
     return {
       micPaused: this.micPaused,
       bufferedFrames: this.micFrames.length,
-      hasVisionSample: Boolean(this.lastVisionSample)
+      hasVisionSample: Boolean(this.lastVisionSample),
+      latestVisionTagCount: this.lastVisionSample?.tags.length ?? 0,
+      latestVisionCapturedAt: this.lastVisionSample?.capturedAt ?? null
     };
   }
 

--- a/src/public/app.js
+++ b/src/public/app.js
@@ -35,6 +35,7 @@ let micCheckProbeInFlight = false;
 let latestCaptionText = "";
 let latestStatusPayload = null;
 let simulationActionInFlight = false;
+let statusAutoRefreshInterval = null;
 let latestDeviceVerification = {
   micPermission: false,
   cameraPermission: false,
@@ -49,6 +50,7 @@ const MIC_CHECK_BUFFER_SECONDS = 8;
 const MIC_CHECK_MIN_SAMPLES = 12000;
 const CAMERA_FRAME_CONFIRM_TIMEOUT_MS = 3000;
 const LIVE_MONITOR_VISION_SAMPLE_MS = 8000;
+const STATUS_AUTO_REFRESH_MS = 5000;
 const STT_DEFAULT_ENDPOINTS = {
   "local-whisper": "http://127.0.0.1:7778/stt",
   whispercpp: "http://127.0.0.1:7778/stt",
@@ -700,6 +702,7 @@ function summarizeVisionHealth(payload) {
   const useRealCapture = Boolean(capture.useRealCapture);
   const endpoint = capture.visionEndpoint ?? "n/a";
   const hasVisionSample = Boolean(payload.privacy?.captureBuffer?.hasVisionSample);
+  const latestVisionTagCount = Number(payload.privacy?.captureBuffer?.latestVisionTagCount ?? 0);
   const hasCloudKey = Boolean(payload.secrets?.hasCloudKey);
 
   let ready = true;
@@ -718,12 +721,16 @@ function summarizeVisionHealth(payload) {
 
   const sampleStatus = enabled
     ? hasVisionSample
-      ? "latest sample present"
+      ? latestVisionTagCount > 0
+        ? "latest sample present"
+        : "sample present, awaiting tag extraction"
       : "waiting for first sample"
     : "not collecting";
   const detailWithHint = sampleStatus === "waiting for first sample" && enabled && useRealCapture
     ? `${detail}; run Start Simulation and confirm the vision endpoint is producing tags (webcam permission alone does not populate visionTags).`
-    : detail;
+    : sampleStatus === "sample present, awaiting tag extraction"
+      ? `${detail}; camera frames are arriving but provider parsing returned no tags yet. Check meta warnings/providerResponse/rawText for diagnosis.`
+      : detail;
 
   visionHealthSummary.textContent = [
     `Vision enabled: ${enabled ? "yes" : "no"}`,
@@ -1237,6 +1244,7 @@ liveMonitorEnabled?.addEventListener("change", async () => {
 window.addEventListener("beforeunload", () => {
   stopLiveMonitor();
   stopMicVerificationCheck();
+  if (statusAutoRefreshInterval) clearInterval(statusAutoRefreshInterval);
 });
 
 const events = new EventSource("/api/events");
@@ -1274,6 +1282,13 @@ events.addEventListener("messages", (event) => {
 
 events.addEventListener("meta", (event) => {
   const meta = JSON.parse(event.data);
+  const visionTags = Array.isArray(meta?.vision?.tags) ? meta.vision.tags.filter((tag) => typeof tag === "string") : null;
+  if (latestStatusPayload && latestStatusPayload.privacy?.captureBuffer && visionTags) {
+    latestStatusPayload.privacy.captureBuffer.hasVisionSample = true;
+    latestStatusPayload.privacy.captureBuffer.latestVisionTagCount = visionTags.length;
+    latestStatusPayload.privacy.captureBuffer.latestVisionCapturedAt = Date.now();
+    summarizeVisionHealth(latestStatusPayload);
+  }
   if (meta?.queueMessages) {
     meta.queuePreview = meta.queueMessages.slice(0, 3);
     delete meta.queueMessages;
@@ -1308,6 +1323,12 @@ async function boot() {
   setCaptionPreview("No speech captured yet.");
   setCaptionStatus("Run Verify Microphone to start mic/STT check.", "warn");
   ensureVerifyCameraButtonActive();
+  if (statusAutoRefreshInterval) clearInterval(statusAutoRefreshInterval);
+  statusAutoRefreshInterval = setInterval(() => {
+    refreshStatus().catch(() => {
+      /* ignore transient polling errors; next interval retries */
+    });
+  }, STATUS_AUTO_REFRESH_MS);
 }
 
 void boot();

--- a/src/services/visionPollingService.ts
+++ b/src/services/visionPollingService.ts
@@ -65,6 +65,16 @@ function normalizeVisionTags(payload: VisionEndpointPayload): string[] {
     .slice(0, 8);
 }
 
+function payloadHasVisionSignal(payload: VisionEndpointPayload): boolean {
+  if (normalizeVisionTags(payload).length > 0) return true;
+  return Boolean(
+    payload.dataUrl ||
+    payload.imageBase64 ||
+    payload.imageUrl ||
+    payload.frameUrl
+  );
+}
+
 function parseVisionTagsFromText(rawText: string): string[] {
   return rawText
     .split(/[,\n;|]/g)
@@ -165,11 +175,23 @@ export class VisionPollingService {
     try {
       let endpointPayload: VisionEndpointPayload = {};
       if (config.capture.visionEndpoint) {
-        const endpointResponse = await fetch(config.capture.visionEndpoint, { signal: AbortSignal.timeout(3000) });
-        if (!endpointResponse.ok) {
-          throw new Error(`vision endpoint failed (${endpointResponse.status})`);
+        try {
+          const endpointResponse = await fetch(config.capture.visionEndpoint, { signal: AbortSignal.timeout(3000) });
+          if (!endpointResponse.ok) {
+            throw new Error(`vision endpoint failed (${endpointResponse.status})`);
+          }
+          endpointPayload = ((await endpointResponse.json()) ?? {}) as VisionEndpointPayload;
+        } catch (endpointError) {
+          if (config.capture.visionProvider !== "openai") throw endpointError;
+          const latestFrame = sharedVisionFrameStore.getLatestFrame();
+          if (!latestFrame) throw endpointError;
+          endpointPayload = { dataUrl: latestFrame.dataUrl };
+          this.emitMeta({
+            warnings: [`Vision endpoint unavailable; falling back to latest browser frame (${explainVisionPollingError(endpointError instanceof Error ? endpointError.message : String(endpointError))}).`],
+            blocked: false,
+            vision: { provider: config.capture.visionProvider, source: "live-monitor-fallback", ok: true }
+          });
         }
-        endpointPayload = ((await endpointResponse.json()) ?? {}) as VisionEndpointPayload;
       } else if (config.capture.visionProvider === "openai") {
         const latestFrame = sharedVisionFrameStore.getLatestFrame();
         if (!latestFrame) {
@@ -190,6 +212,17 @@ export class VisionPollingService {
         });
         this.scheduleNext(delayMs);
         return;
+      }
+      if (config.capture.visionProvider === "openai" && !payloadHasVisionSignal(endpointPayload)) {
+        const latestFrame = sharedVisionFrameStore.getLatestFrame();
+        if (latestFrame) {
+          endpointPayload = { ...endpointPayload, dataUrl: latestFrame.dataUrl };
+          this.emitMeta({
+            warnings: ["Vision endpoint returned no image/tags; using latest browser frame for OpenAI tagging."],
+            blocked: false,
+            vision: { provider: config.capture.visionProvider, source: "live-monitor-fallback", ok: true }
+          });
+        }
       }
       // eslint-disable-next-line no-console
       console.log("[VisionPollingService] vision endpoint payload", endpointPayload);

--- a/tests/captureProviders.test.ts
+++ b/tests/captureProviders.test.ts
@@ -203,6 +203,70 @@ describe("VisionPollingService", () => {
     expect(context.visionTags).toEqual(["ring light", "keyboard"]);
   });
 
+  it("falls back to live-monitor frame when vision endpoint returns empty payload for OpenAI provider", async () => {
+    const config = {
+      ...defaultConfig,
+      provider: { ...defaultConfig.provider, cloudEndpoint: "https://api.openai.com/v1/chat/completions", cloudModel: "gpt-4o-mini" },
+      capture: {
+        ...defaultConfig.capture,
+        visionEnabled: true,
+        useRealCapture: true,
+        visionProvider: "openai" as const,
+        visionEndpoint: "http://127.0.0.1:7778/vision-tags"
+      }
+    };
+    sharedVisionFrameStore.setFrame("data:image/jpeg;base64,abcd1234==");
+    const emitMeta = vi.fn();
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/vision-tags")) return { ok: true, json: async () => ({}) };
+      return { ok: true, json: async () => ({ choices: [{ message: { content: "ring light, keyboard" } }] }) };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const service = new VisionPollingService(() => config, emitMeta);
+    await (service as any).tick();
+    const context = sharedDeviceCapturePipeline.getContext(config);
+    expect(context.visionTags).toEqual(["ring light", "keyboard"]);
+    expect(emitMeta).toHaveBeenCalledWith(
+      expect.objectContaining({
+        warnings: expect.arrayContaining([expect.stringContaining("using latest browser frame")])
+      })
+    );
+  });
+
+  it("falls back to live-monitor frame when vision endpoint errors for OpenAI provider", async () => {
+    const config = {
+      ...defaultConfig,
+      provider: { ...defaultConfig.provider, cloudEndpoint: "https://api.openai.com/v1/chat/completions", cloudModel: "gpt-4o-mini" },
+      capture: {
+        ...defaultConfig.capture,
+        visionEnabled: true,
+        useRealCapture: true,
+        visionProvider: "openai" as const,
+        visionEndpoint: "http://127.0.0.1:7778/vision-tags"
+      }
+    };
+    sharedVisionFrameStore.setFrame("data:image/jpeg;base64,abcd1234==");
+    const emitMeta = vi.fn();
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/vision-tags")) return { ok: false, status: 503, json: async () => ({}) };
+      return { ok: true, json: async () => ({ choices: [{ message: { content: "ring light, keyboard" } }] }) };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const service = new VisionPollingService(() => config, emitMeta);
+    await (service as any).tick();
+    const context = sharedDeviceCapturePipeline.getContext(config);
+    expect(context.visionTags).toEqual(["ring light", "keyboard"]);
+    expect(emitMeta).toHaveBeenCalledWith(
+      expect.objectContaining({
+        warnings: expect.arrayContaining([expect.stringContaining("Vision endpoint unavailable; falling back to latest browser frame")])
+      })
+    );
+  });
+
   it("falls back to gpt-4o-mini when primary OpenAI vision model is rate-limited", async () => {
     const config = {
       ...defaultConfig,


### PR DESCRIPTION
### Motivation
- Improve robustness of vision tag collection when the configured vision endpoint is unavailable or returns no image/tags, especially for the OpenAI provider.
- Surface more useful capture diagnostics about the latest vision sample to the UI.
- Keep the status UI up-to-date by polling the server periodically.

### Description
- Add `latestVisionTagCount` and `latestVisionCapturedAt` to the capture diagnostics returned by `DeviceCapturePipeline.diagnostics()` in `src/capture/deviceCapturePipeline.ts`.
- Update the web UI in `src/public/app.js` to auto-refresh the `/api/status` endpoint on an interval (`STATUS_AUTO_REFRESH_MS`), wire up `statusAutoRefreshInterval` lifecycle cleanup, and incorporate `latestVisionTagCount` into the vision health summary to show finer-grained sample states and hints.
- In `src/services/visionPollingService.ts`, introduce `payloadHasVisionSignal()` and make the vision endpoint fetch logic more resilient by catching endpoint errors and falling back to the latest browser frame when the provider is `openai`, including emitting helpful `meta` warnings explaining the fallback.
- Add unit tests in `tests/captureProviders.test.ts` that verify the OpenAI-specific fallback behaviors when the vision endpoint returns an empty payload or errors, and assert `emitMeta` is called with appropriate warnings.

### Testing
- Ran the unit test suite with `vitest` and executed the `VisionPollingService` tests, including the two new fallback tests in `tests/captureProviders.test.ts`, and they passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9bd5cffa08324b012de246ddf45ed)