### PR TITLE
Refocus OpenAI vision tagging on streamer activity and remove generic tags

### DIFF
--- a/src/services/visionPollingService.ts
+++ b/src/services/visionPollingService.ts
@@ -32,6 +32,37 @@ const VISION_MODEL_FALLBACKS: Record<string, string[]> = {
   "gpt-5-mini": ["gpt-4o-mini"]
 };
 
+const DEAD_VISION_TAGS = new Set([
+  "person",
+  "people",
+  "human",
+  "man",
+  "woman",
+  "boy",
+  "girl",
+  "face",
+  "game",
+  "gaming",
+  "room",
+  "indoors",
+  "indoor",
+  "camera",
+  "webcam",
+  "stream",
+  "streamer",
+  "video",
+  "monitor"
+]);
+
+function filterDeadVisionTags(tags: string[]): string[] {
+  return tags
+    .map((tag) => tag.trim().toLowerCase())
+    .filter(Boolean)
+    .filter((tag) => !DEAD_VISION_TAGS.has(tag))
+    .filter((tag, index, arr) => arr.indexOf(tag) === index)
+    .slice(0, 8);
+}
+
 export function explainVisionPollingError(reason: string): string {
   if (reason.includes("Unexpected end of JSON input")) {
     return "Vision endpoint returned truncated JSON (broken package).";
@@ -53,16 +84,17 @@ function normalizeVisionTags(payload: VisionEndpointPayload): string[] {
     .map((tag) => tag.trim())
     .filter(Boolean);
 
-  if (listTags.length > 0) return listTags.slice(0, 8);
+  if (listTags.length > 0) return filterDeadVisionTags(listTags);
 
   const caption = [payload.description, payload.caption, payload.text].find((value): value is string => typeof value === "string" && value.trim().length > 0);
   if (!caption) return [];
 
-  return caption
+  return filterDeadVisionTags(
+    caption
     .split(/[|,;\n]/g)
     .map((part) => part.trim())
     .filter(Boolean)
-    .slice(0, 8);
+  );
 }
 
 function payloadHasVisionSignal(payload: VisionEndpointPayload): boolean {
@@ -76,13 +108,12 @@ function payloadHasVisionSignal(payload: VisionEndpointPayload): boolean {
 }
 
 function parseVisionTagsFromText(rawText: string): string[] {
-  return rawText
+  return filterDeadVisionTags(rawText
     .split(/[,\n;|]/g)
     .map((chunk) => chunk.trim())
     .map((chunk) => chunk.replace(/^[-*•\d.)\s]+/, "").trim())
     .map((chunk) => chunk.replace(/^["'`]+|["'`]+$/g, "").trim().toLowerCase())
-    .filter(Boolean)
-    .slice(0, 8);
+    .filter(Boolean));
 }
 
 function tryParseJsonTags(rawText: string): string[] {
@@ -91,11 +122,10 @@ function tryParseJsonTags(rawText: string): string[] {
   try {
     const parsed = JSON.parse(trimmed) as { tags?: unknown };
     if (!Array.isArray(parsed.tags)) return [];
-    return parsed.tags
+    return filterDeadVisionTags(parsed.tags
       .filter((tag): tag is string => typeof tag === "string")
       .map((tag) => tag.trim().toLowerCase())
-      .filter(Boolean)
-      .slice(0, 8);
+      .filter(Boolean));
   } catch {
     return [];
   }
@@ -302,11 +332,16 @@ export class VisionPollingService {
           model,
           messages: [
             {
+              role: "system",
+              content:
+                "You are a stream-vision tagger. Prioritize streamer activity, facial expressions, body language, and scene energy (example outputs: focused expression, leaning in, adjusting headset, dim gaming vibe). Avoid static object lists unless they directly explain action/mood. Exclude generic dead tags such as person, man, woman, game, room, camera, monitor, stream, and video."
+            },
+            {
               role: "user",
               content: [
                 {
                   type: "text",
-                  text: 'Return strict JSON: {"tags":["tag1","tag2","tag3"]}. Keep tags short concrete nouns/adjectives from the frame.'
+                  text: 'Return strict JSON: {"tags":["tag1","tag2","tag3"]}. Use short phrase-style tags focused on actions/expressions/energy (not generic object labels).'
                 },
                 {
                   type: "image_url",

--- a/tests/captureProviders.test.ts
+++ b/tests/captureProviders.test.ts
@@ -141,6 +141,35 @@ describe("VisionPollingService", () => {
     expect(context.visionTags).toEqual(["green hoodie", "gaming headset", "ring light"]);
   });
 
+  it("filters generic dead tags and keeps activity/expression hooks", async () => {
+    const config = {
+      ...defaultConfig,
+      provider: { ...defaultConfig.provider, cloudEndpoint: "https://api.openai.com/v1/chat/completions", cloudModel: "gpt-4o-mini" },
+      capture: {
+        ...defaultConfig.capture,
+        visionEnabled: true,
+        useRealCapture: true,
+        visionProvider: "openai" as const,
+        visionEndpoint: ""
+      }
+    };
+    sharedVisionFrameStore.setFrame("data:image/jpeg;base64,abcd1234==");
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ choices: [{ message: { content: '{"tags":["person","focused expression","man","leaning in","game"]}' } }] })
+      }))
+    );
+
+    const service = new VisionPollingService(() => config, () => undefined);
+    await (service as any).tick();
+
+    const context = sharedDeviceCapturePipeline.getContext(config);
+    expect(context.visionTags).toEqual(["focused expression", "leaning in"]);
+  });
+
   it("parses JSON-tagged OpenAI vision responses", async () => {
     const config = {
       ...defaultConfig,
@@ -325,6 +354,38 @@ describe("VisionPollingService", () => {
     const service = new VisionPollingService(() => config, () => undefined);
     await (service as any).tick();
     expect(String(fetchMock.mock.calls[0][0])).toBe("https://api.openai.com/v1/chat/completions");
+  });
+
+  it("sends action-and-expression focused system prompt for OpenAI vision", async () => {
+    const config = {
+      ...defaultConfig,
+      provider: { ...defaultConfig.provider, cloudEndpoint: "https://api.openai.com/v1/chat/completions", cloudModel: "gpt-4o-mini" },
+      capture: {
+        ...defaultConfig.capture,
+        visionEnabled: true,
+        useRealCapture: true,
+        visionProvider: "openai" as const,
+        visionEndpoint: ""
+      }
+    };
+    sharedVisionFrameStore.setFrame("data:image/jpeg;base64,abcd1234==");
+
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ choices: [{ message: { content: "focused expression, leaning in" } }] })
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const service = new VisionPollingService(() => config, () => undefined);
+    await (service as any).tick();
+
+    const callInit = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    const requestBody = JSON.parse(String(callInit.body)) as { messages?: Array<{ role?: string; content?: string }> };
+    const systemPrompt = requestBody.messages?.find((entry) => entry.role === "system")?.content ?? "";
+    expect(systemPrompt).toMatch(/stream-vision tagger/i);
+    expect(systemPrompt).toMatch(/activity/i);
+    expect(systemPrompt).toMatch(/facial expressions/i);
+    expect(systemPrompt).toMatch(/dead tags/i);
   });
 
   it("emits warning metadata when provider responds but produces empty tags", async () => {


### PR DESCRIPTION
### Motivation
- Vision tag output was too generic and object-focused, producing low-signal labels that made chat act like a security camera instead of reacting to streamer activity and mood.
- Improve conversational hooks by prioritizing actions, facial expressions, body language, and scene energy and removing generic "dead" tags like `person`, `man`, `game`, `room`, etc.

### Description
- Added a `DEAD_VISION_TAGS` set and `filterDeadVisionTags` helper to remove low-signal generic labels and deduplicate/tag-limit results. (src/services/visionPollingService.ts)
- Applied the dead-tag filtering to all vision ingestion paths including endpoint list normalization, caption/text parsing, and JSON-parsed tags. (src/services/visionPollingService.ts)
- Injected an action-and-expression-focused `system` prompt and updated the `user` vision instruction for OpenAI requests to request short phrase-style tags centered on activity/expressions/energy. (src/services/visionPollingService.ts)
- Added tests to assert that generic dead tags are filtered and that the OpenAI vision request contains the new system prompt. (tests/captureProviders.test.ts)

### Testing
- Ran `npm test -- tests/captureProviders.test.ts` which executed the updated vision tests under `vitest` and all tests passed (15 tests, 1 file).
- New assertions verify filtered tag output (`["focused expression","leaning in"]`) and presence of the action/expression-focused system prompt in the OpenAI request.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9d8ca948883249c30bf002d300449)