### PR TITLE
Redesign Control Center into guided dual-mode workflow UI

### DIFF
--- a/src/public/app.js
+++ b/src/public/app.js
@@ -17,6 +17,22 @@ const liveVideo = document.getElementById("liveVideo");
 const voiceMeter = document.getElementById("voiceMeter");
 const sttCaptionStatus = document.getElementById("sttCaptionStatus");
 const sttCaptionPreview = document.getElementById("sttCaptionPreview");
+const uiModeSelect = document.getElementById("uiMode");
+const systemStateBadge = document.getElementById("systemStateBadge");
+const statusCards = document.getElementById("statusCards");
+const connectStatusPill = document.getElementById("connectStatusPill");
+const logsToggleBtn = document.getElementById("logsToggle");
+const logsPanel = document.getElementById("logsPanel");
+const logsContent = document.getElementById("logsContent");
+const logFilter = document.getElementById("logFilter");
+const logSearch = document.getElementById("logSearch");
+const previewViewerCount = document.getElementById("previewViewerCount");
+const previewAlerts = document.getElementById("previewAlerts");
+const sendTestChatBtn = document.getElementById("sendTestChat");
+const triggerTestDonationBtn = document.getElementById("triggerTestDonation");
+const simulateViewerSpikeBtn = document.getElementById("simulateViewerSpike");
+const liveFrame = document.getElementById("liveFrame");
+const liveBadge = document.getElementById("liveBadge");
 
 let liveMonitorStream = null;
 let liveMonitorAudioContext = null;
@@ -36,6 +52,9 @@ let latestCaptionText = "";
 let latestStatusPayload = null;
 let simulationActionInFlight = false;
 let statusAutoRefreshInterval = null;
+let uiMode = "operator";
+let logEntries = [];
+let previewAlertCount = 0;
 let latestDeviceVerification = {
   micPermission: false,
   cameraPermission: false,
@@ -99,6 +118,7 @@ function setStatus(message, tone = "success") {
   statusBanner.textContent = message;
   statusBanner.classList.remove("success", "warn", "error");
   statusBanner.classList.add(tone);
+  addLog("system", tone === "error" ? "error" : tone === "warn" ? "warn" : "info", message);
 }
 
 function setLiveMonitorStatus(message, tone = "warn") {
@@ -113,11 +133,47 @@ function setCaptionStatus(message, tone = "warn") {
   sttCaptionStatus.textContent = message;
   sttCaptionStatus.classList.remove("ok", "warn", "error");
   sttCaptionStatus.classList.add(tone);
+  addLog("stt", tone === "error" ? "error" : "info", message);
 }
 
 function setCaptionPreview(text) {
   if (!sttCaptionPreview) return;
   sttCaptionPreview.textContent = text?.trim() || "No speech captured yet.";
+}
+
+function setMode(nextMode) {
+  uiMode = nextMode === "developer" ? "developer" : "operator";
+  document.body.dataset.uiMode = uiMode;
+  if (uiModeSelect) uiModeSelect.value = uiMode;
+  localStorage.setItem("streamsim-ui-mode", uiMode);
+}
+
+function addLog(area, level, message) {
+  const timestamp = new Date().toLocaleTimeString();
+  logEntries.unshift({ area, level, message, timestamp });
+  if (logEntries.length > 200) logEntries = logEntries.slice(0, 200);
+  renderLogs();
+}
+
+function renderLogs() {
+  if (!logsContent) return;
+  const filter = logFilter?.value || "all";
+  const query = (logSearch?.value || "").toLowerCase().trim();
+  const rows = logEntries
+    .filter((entry) => (filter === "all" ? true : entry.area === filter))
+    .filter((entry) => (!query ? true : `${entry.area} ${entry.level} ${entry.message}`.toLowerCase().includes(query)))
+    .slice(0, 80)
+    .map((entry) => `[${entry.timestamp}] [${entry.area.toUpperCase()}] ${entry.level.toUpperCase()} — ${entry.message}`);
+  logsContent.textContent = rows.length ? rows.join("\n") : "No logs yet.";
+}
+
+function updateRangeLabels() {
+  const viewerValue = document.getElementById("viewerCountValue");
+  const engagementValue = document.getElementById("engagementMultiplierValue");
+  const donationValue = document.getElementById("donationFrequencyValue");
+  if (viewerValue) viewerValue.textContent = controls.viewerCount.value;
+  if (engagementValue) engagementValue.textContent = Number(controls.engagementMultiplier.value).toFixed(1);
+  if (donationValue) donationValue.textContent = Number(controls.donationFrequency.value).toFixed(2);
 }
 
 function encodePcm16Wav(samples, sampleRate) {
@@ -371,6 +427,11 @@ function stopLiveMonitor() {
   }
   liveMonitorVisionCanvas = null;
   if (liveVideo) liveVideo.srcObject = null;
+  if (liveFrame) liveFrame.classList.remove("active");
+  if (liveBadge) {
+    liveBadge.textContent = "OFFLINE";
+    liveBadge.classList.remove("live");
+  }
   drawVoiceMeter(0);
   setLiveMonitorStatus("Live monitor disabled.", "warn");
 }
@@ -399,6 +460,11 @@ async function startLiveMonitor() {
   const stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: true });
   liveMonitorStream = stream;
   if (liveVideo) liveVideo.srcObject = stream;
+  if (liveFrame) liveFrame.classList.add("active");
+  if (liveBadge) {
+    liveBadge.textContent = "LIVE";
+    liveBadge.classList.add("live");
+  }
 
   const AudioContextCtor = window.AudioContext || window.webkitAudioContext;
   if (!AudioContextCtor) {
@@ -441,6 +507,21 @@ function setSimulationActionPending(isPending) {
   simulationActionInFlight = isPending;
   if (startBtn) startBtn.disabled = isPending;
   if (stopBtn) stopBtn.disabled = isPending;
+  setSystemStateBadge();
+}
+
+function setSystemStateBadge(payload = latestStatusPayload) {
+  if (!systemStateBadge) return;
+  let state = "idle";
+  if (simulationActionInFlight || payload?.ai?.state === "running") {
+    state = "running";
+  }
+  if (String(statusBanner?.className || "").includes("error")) {
+    state = "error";
+  }
+  systemStateBadge.textContent = state.charAt(0).toUpperCase() + state.slice(1);
+  systemStateBadge.classList.remove("idle", "running", "error");
+  systemStateBadge.classList.add(state);
 }
 
 async function runAction({ button, pendingText, successText, onRun }) {
@@ -537,6 +618,7 @@ function hydrateControls(config) {
   controls.allowNonLocalSidecarOverride.checked = config.security.allowNonLocalSidecarOverride;
   controls.eulaAccepted.checked = config.compliance.eulaAccepted;
   if (wizardEulaAccepted) wizardEulaAccepted.checked = config.compliance.eulaAccepted;
+  updateRangeLabels();
 }
 
 function syncSttEndpointForProvider() {
@@ -556,6 +638,8 @@ function renderOnboardingState(payload) {
     onboardingPill.classList.toggle("complete", onboardingDone);
     onboardingPill.classList.toggle("pending", !onboardingDone);
   }
+  const setupSection = document.getElementById("sectionSetup");
+  if (setupSection) setupSection.open = !onboardingDone;
 }
 
 function syncEulaCheckboxes(source) {
@@ -782,6 +866,37 @@ function summarizeApiKeyHealth(payload) {
     `Cloud key detected: ${hasCloudKey ? "yes" : "no"}`,
     `Deepgram key detected: ${hasDeepgramKey ? "yes" : "no"}`
   ].join("\n");
+}
+
+function deriveCardTone(statusText) {
+  const normalized = String(statusText || "").toLowerCase();
+  if (normalized.includes("missing") || normalized.includes("failed") || normalized.includes("error") || normalized.includes("no")) return "error";
+  if (normalized.includes("waiting") || normalized.includes("degraded") || normalized.includes("optional") || normalized.includes("simulated")) return "warn";
+  if (normalized.includes("off") || normalized.includes("disabled") || normalized.includes("inactive")) return "inactive";
+  return "ok";
+}
+
+function renderStatusCards(payload) {
+  if (!statusCards) return;
+  const cards = [
+    { label: "AI", summary: payload?.ai?.providerHealth ?? "unknown", detail: payload?.ai?.detail ?? "pending" },
+    { label: "STT", summary: (sttHealthSummary?.textContent || "").split("\n")[2] ?? "pending", detail: (sttHealthSummary?.textContent || "").split("\n")[3] ?? "" },
+    { label: "TTS", summary: (ttsHealthSummary?.textContent || "").split("\n")[2] ?? "pending", detail: (ttsHealthSummary?.textContent || "").split("\n")[3] ?? "" },
+    { label: "Vision", summary: (visionHealthSummary?.textContent || "").split("\n")[4] ?? "pending", detail: (visionHealthSummary?.textContent || "").split("\n")[5] ?? "" },
+    { label: "Microphone", summary: latestDeviceVerification.micPermission ? "ready" : "not verified", detail: latestCaptionText ? `Latest: ${latestCaptionText}` : "Run Verify Microphone" },
+    { label: "Camera", summary: latestDeviceVerification.cameraPermission ? "ready" : "not verified", detail: latestDeviceVerification.cameraFailureReason ?? "Run Verify Camera" },
+    { label: "Network", summary: diagnosticsSummary?.textContent?.includes("pending") ? "pending" : diagnosticsSummary.textContent.split("\n")[1] ?? "pending", detail: "Boot diagnostics probe" },
+    { label: "Credentials", summary: (apiKeyHealthSummary?.textContent || "").includes("missing") ? "partial" : "ready", detail: "Cloud + Deepgram key checks" }
+  ];
+
+  statusCards.innerHTML = "";
+  cards.forEach((card) => {
+    const article = document.createElement("article");
+    const tone = deriveCardTone(`${card.summary} ${card.detail}`);
+    article.className = `status-card ${tone}`;
+    article.innerHTML = `<h4>${card.label}</h4><p>${card.summary}</p><p>${card.detail}</p>`;
+    statusCards.appendChild(article);
+  });
 }
 
 function renderDeviceChecks(result) {
@@ -1089,12 +1204,21 @@ async function refreshStatus() {
   renderDiagnostics(payload);
   hydrateControls(payload.config);
   renderOnboardingState(payload);
+  if (previewViewerCount) previewViewerCount.textContent = `👥 ${payload.config.viewerCount ?? 0}`;
   summarizeRuntime(payload);
   summarizeAiHealth(payload);
   summarizeTtsHealth(payload);
   summarizeSttHealth(payload);
   summarizeApiKeyHealth(payload);
   summarizeVisionHealth(payload);
+  renderStatusCards(payload);
+  setSystemStateBadge(payload);
+  const hasMissingKey = (apiKeyHealthSummary?.textContent || "").includes("missing");
+  if (connectStatusPill) {
+    connectStatusPill.textContent = hasMissingKey ? "Partial" : "Connected";
+    connectStatusPill.classList.toggle("pending", hasMissingKey);
+    connectStatusPill.classList.toggle("complete", !hasMissingKey);
+  }
   return payload;
 }
 
@@ -1222,6 +1346,33 @@ controls.sttProvider?.addEventListener("change", () => {
   syncSttEndpointForProvider();
 });
 
+[controls.viewerCount, controls.engagementMultiplier, controls.donationFrequency].forEach((input) => {
+  input?.addEventListener("input", updateRangeLabels);
+});
+
+uiModeSelect?.addEventListener("change", () => {
+  setMode(uiModeSelect.value);
+});
+
+logsToggleBtn?.addEventListener("click", () => {
+  logsPanel?.classList.toggle("hidden");
+});
+
+logFilter?.addEventListener("change", renderLogs);
+logSearch?.addEventListener("input", renderLogs);
+
+window.addEventListener("keydown", (event) => {
+  if (!(event.metaKey || event.ctrlKey)) return;
+  if (event.key.toLowerCase() === "d") {
+    event.preventDefault();
+    setMode(uiMode === "developer" ? "operator" : "developer");
+  }
+  if (event.key.toLowerCase() === "l") {
+    event.preventDefault();
+    logsPanel?.classList.toggle("hidden");
+  }
+});
+
 liveMonitorEnabled?.addEventListener("change", async () => {
   if (!liveMonitorEnabled.checked) {
     stopLiveMonitor();
@@ -1248,8 +1399,7 @@ window.addEventListener("beforeunload", () => {
 });
 
 const events = new EventSource("/api/events");
-events.addEventListener("messages", (event) => {
-  const messages = JSON.parse(event.data);
+function renderIncomingMessages(messages) {
   messages.forEach((msg) => {
     const item = document.createElement("div");
     item.className = "chat-msg";
@@ -1277,7 +1427,13 @@ events.addEventListener("messages", (event) => {
 
     chatEl.prepend(item);
     while (chatEl.children.length > 22) chatEl.lastChild.remove();
+    addLog("system", "event", `${msg.source ?? "unknown"} message from ${msg.username ?? "anon"}`);
   });
+}
+
+events.addEventListener("messages", (event) => {
+  const messages = JSON.parse(event.data);
+  renderIncomingMessages(messages);
 });
 
 events.addEventListener("meta", (event) => {
@@ -1297,9 +1453,30 @@ events.addEventListener("meta", (event) => {
   const recovery = meta.cloudRecovery ? `Recovery=${meta.cloudRecovery}` : "";
   const banner = warningLines.length ? `⚠️ ${warningLines.join(" | ")} ${recovery}`.trim() + "\n" : "";
   metaEl.textContent = `${banner}${JSON.stringify(meta, null, 2)}`;
+  if (warningLines.length) addLog("network", "warn", warningLines.join(" | "));
+});
+
+sendTestChatBtn?.addEventListener("click", () => {
+  renderIncomingMessages([{ username: "test_user", text: "This is a test chat message", emotes: [], source: "test" }]);
+});
+
+triggerTestDonationBtn?.addEventListener("click", () => {
+  previewAlertCount += 1;
+  if (previewAlerts) previewAlerts.textContent = `🔔 ${previewAlertCount}`;
+  renderIncomingMessages([{ username: "donor42", text: "Great stream!", donationCents: 500, emotes: [], source: "test" }]);
+});
+
+simulateViewerSpikeBtn?.addEventListener("click", () => {
+  const current = Number(controls.viewerCount.value);
+  const boosted = Math.min(5000, current + 250);
+  controls.viewerCount.value = String(boosted);
+  updateRangeLabels();
+  if (previewViewerCount) previewViewerCount.textContent = `👥 ${boosted}`;
+  addLog("system", "event", `Viewer spike simulated to ${boosted}`);
 });
 
 async function boot() {
+  setMode(localStorage.getItem("streamsim-ui-mode") || "operator");
   const response = await fetch("/api/status");
   const payload = await response.json();
   latestStatusPayload = payload;
@@ -1313,6 +1490,8 @@ async function boot() {
   summarizeSttHealth(payload);
   summarizeApiKeyHealth(payload);
   summarizeVisionHealth(payload);
+  renderStatusCards(payload);
+  setSystemStateBadge(payload);
   latestDeviceVerification = { micPermission: false, cameraPermission: false, hasMicDevice: false, hasCameraDevice: false, cameraPermissionState: "unknown", cameraFailureReason: null };
   if (liveMonitorEnabled) {
     liveMonitorEnabled.checked = false;
@@ -1323,6 +1502,9 @@ async function boot() {
   setCaptionPreview("No speech captured yet.");
   setCaptionStatus("Run Verify Microphone to start mic/STT check.", "warn");
   ensureVerifyCameraButtonActive();
+  if (previewViewerCount) previewViewerCount.textContent = `👥 ${payload.config.viewerCount ?? 0}`;
+  if (previewAlerts) previewAlerts.textContent = "🔔 0";
+  addLog("system", "info", "UI boot complete.");
   if (statusAutoRefreshInterval) clearInterval(statusAutoRefreshInterval);
   statusAutoRefreshInterval = setInterval(() => {
     refreshStatus().catch(() => {

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -9,187 +9,256 @@
   <body>
     <main class="layout">
       <section class="panel controls">
-        <h1>StreamSim Control Center</h1>
-
-        <section class="onboarding-panel" id="onboardingPanel">
-          <div class="onboarding-head">
-            <h2>Quick Start Onboarding</h2>
-            <span id="onboardingPill" class="pill pending">Pending</span>
+        <header class="topbar">
+          <div>
+            <h1>StreamSim Control Center</h1>
+            <p class="subtle">Guided simulation workflow with full developer visibility.</p>
           </div>
-          <ol class="onboarding-steps">
-            <li>Choose a provider mode and stream profile (defaults to full AI pipeline).</li>
-            <li>Run readiness + performance checks.</li>
-            <li>Accept EULA to unlock simulation start.</li>
-          </ol>
-          <div class="wizard-inline-controls">
-            <label class="eula"><input id="wizardEulaAccepted" type="checkbox" /> I accept the simulation EULA/compliance terms</label>
-            <div class="buttons">
-              <button id="runReadiness" type="button">Run Readiness</button>
-              <button id="completeWizard" type="button" class="primary">Complete onboarding</button>
+          <div class="topbar-actions">
+            <label class="mode-switch">Mode
+              <select id="uiMode">
+                <option value="operator">Operator</option>
+                <option value="developer">Developer</option>
+              </select>
+            </label>
+            <span id="systemStateBadge" class="state-pill idle">Idle</span>
+          </div>
+        </header>
+
+        <div class="workflow-stack">
+          <details class="control-group workflow-section" id="sectionSetup" open>
+            <summary><span>1. Setup</span><span id="onboardingPill" class="pill pending">Pending</span></summary>
+            <section class="onboarding-panel" id="onboardingPanel">
+              <ol class="onboarding-steps">
+                <li>Choose provider mode and stream profile.</li>
+                <li>Run readiness + performance checks.</li>
+                <li>Accept EULA to unlock simulation start.</li>
+              </ol>
+              <div class="wizard-inline-controls">
+                <label class="eula"><input id="wizardEulaAccepted" type="checkbox" /> I accept the simulation EULA/compliance terms</label>
+                <div class="buttons">
+                  <button id="runReadiness" type="button">Run Readiness</button>
+                  <button id="completeWizard" type="button" class="primary">Complete onboarding</button>
+                </div>
+                <ul id="readinessList"></ul>
+              </div>
+            </section>
+          </details>
+
+          <details class="control-group workflow-section" id="sectionConfigure" open>
+            <summary><span>2. Configure</span><span class="pill neutral">Profile</span></summary>
+            <div class="grid compact-grid">
+              <label>Viewer Count
+                <input id="viewerCount" type="range" min="1" max="5000" value="100" />
+                <span class="range-value" id="viewerCountValue">100</span>
+              </label>
+              <label>Engagement Multiplier
+                <input id="engagementMultiplier" type="range" min="0.1" max="3" step="0.1" value="1" />
+                <span class="range-value" id="engagementMultiplierValue">1.0</span>
+              </label>
+              <label>Donation Frequency
+                <input id="donationFrequency" type="range" min="0" max="1" step="0.01" value="0.08" />
+                <span class="range-value" id="donationFrequencyValue">0.08</span>
+              </label>
+              <label>Persona
+                <select id="persona">
+                  <option value="supportive">Supportive</option>
+                  <option value="trolls">Trolls</option>
+                  <option value="meme-lords">Meme-lords</option>
+                  <option value="neutral">Neutral</option>
+                </select>
+              </label>
+              <label>Bias
+                <select id="bias">
+                  <option value="split">Split</option>
+                  <option value="agree">Agree</option>
+                  <option value="disagree">Disagree</option>
+                </select>
+              </label>
+              <label>Inference Mode
+                <select id="inferenceMode">
+                  <option value="mock-local">Mock Local</option>
+                  <option value="mock-cloud">Mock Cloud</option>
+                  <option value="ollama">Ollama</option>
+                  <option value="lmstudio">LM Studio</option>
+                  <option value="openai">OpenAI</option>
+                  <option value="groq">Groq</option>
+                </select>
+              </label>
             </div>
-          </div>
-        </section>
+          </details>
 
-        <section class="control-group">
-          <h3>Stream Profile</h3>
-          <div class="grid compact-grid">
-            <label>Viewer Count <input id="viewerCount" type="number" min="1" value="100" /></label>
-            <label>Engagement Multiplier <input id="engagementMultiplier" type="number" step="0.1" value="1" /></label>
-            <label>Donation Frequency <input id="donationFrequency" type="number" step="0.01" min="0" max="1" value="0.08" /></label>
-            <label>Persona
-              <select id="persona">
-                <option value="supportive">Supportive</option>
-                <option value="trolls">Trolls</option>
-                <option value="meme-lords">Meme-lords</option>
-                <option value="neutral">Neutral</option>
-              </select>
-            </label>
-            <label>Bias
-              <select id="bias">
-                <option value="split">Split</option>
-                <option value="agree">Agree</option>
-                <option value="disagree">Disagree</option>
-              </select>
-            </label>
-            <label>Inference Mode
-              <select id="inferenceMode">
-                <option value="mock-local">Mock Local</option>
-                <option value="mock-cloud">Mock Cloud</option>
-                <option value="ollama">Ollama</option>
-                <option value="lmstudio">LM Studio</option>
-                <option value="openai">OpenAI</option>
-                <option value="groq">Groq</option>
-              </select>
-            </label>
-          </div>
-        </section>
+          <details class="control-group workflow-section" id="sectionConnect">
+            <summary><span>3. Connect</span><span id="connectStatusPill" class="pill neutral">Partial</span></summary>
+            <div class="grid">
+              <label>Local endpoint <input id="localEndpoint" type="text" value="http://127.0.0.1:11434" /></label>
+              <label>Local model <input id="localModel" type="text" value="llama3.1:8b-instruct-q4_K_M" /></label>
+              <label>Cloud endpoint <input id="cloudEndpoint" type="text" value="https://api.openai.com/v1/chat/completions" /></label>
+              <label>Cloud model <input id="cloudModel" type="text" value="gpt-5.4-nano-2026-03-17" /></label>
+              <label>Request timeout ms <input id="requestTimeoutMs" type="number" min="1000" max="120000" value="30000" /></label>
+              <label>Max retries <input id="maxRetries" type="number" min="0" max="5" value="1" /></label>
+              <label><input id="ttsEnabled" type="checkbox" checked /> TTS Enabled</label>
+              <label>TTS Path
+                <select id="ttsMode">
+                  <option value="local">Local TTS</option>
+                  <option value="cloud">Cloud TTS</option>
+                  <option value="off">Off</option>
+                </select>
+              </label>
+              <label>TTS Provider
+                <select id="ttsProvider">
+                  <option value="local">Local (no synth call)</option>
+                  <option value="deepgram_aura">Deepgram Aura (Luna)</option>
+                  <option value="openai">OpenAI TTS</option>
+                </select>
+              </label>
+              <label><input id="visionEnabled" type="checkbox" checked /> Vision Capture Enabled</label>
+              <label><input id="useRealCapture" type="checkbox" /> Use real capture endpoints</label>
+              <label>Vision Provider
+                <select id="visionProvider">
+                  <option value="local">Local (moondream/ollama sidecar)</option>
+                  <option value="openai">Cloud (OpenAI)</option>
+                </select>
+              </label>
+              <label>Vision Interval (seconds) <input id="visionIntervalSec" type="number" min="5" max="120" value="25" /></label>
+              <label>STT Provider
+                <select id="sttProvider">
+                  <option value="local-whisper">Local Whisper (localhost)</option>
+                  <option value="mock">Mock STT</option>
+                  <option value="whispercpp">Whisper.cpp (custom endpoint)</option>
+                  <option value="deepgram">Deepgram</option>
+                  <option value="openai-whisper">OpenAI Whisper (cloud)</option>
+                  <option value="gpt-4o-mini-transcribe">OpenAI GPT-4o mini transcribe (cloud)</option>
+                </select>
+              </label>
+              <label>STT endpoint <input id="sttEndpoint" type="text" value="http://127.0.0.1:7778/stt" /></label>
+              <label>Vision endpoint <input id="visionEndpoint" type="text" value="http://127.0.0.1:7778/vision-tags" /></label>
+              <label><input id="audioIntelligenceEnabled" type="checkbox" checked /> Audio Intelligence Enabled</label>
+            </div>
+          </details>
 
-        <details class="control-group">
-          <summary>Provider + Capture Settings</summary>
-          <div class="grid">
-            <label>Local endpoint <input id="localEndpoint" type="text" value="http://127.0.0.1:11434" /></label>
-            <label>Local model <input id="localModel" type="text" value="llama3.1:8b-instruct-q4_K_M" /></label>
-            <label>Cloud endpoint <input id="cloudEndpoint" type="text" value="https://api.openai.com/v1/chat/completions" /></label>
-            <label>Cloud model <input id="cloudModel" type="text" value="gpt-5.4-nano-2026-03-17" /></label>
-            <label>Request timeout ms <input id="requestTimeoutMs" type="number" min="1000" max="120000" value="30000" /></label>
-            <label>Max retries <input id="maxRetries" type="number" min="0" max="5" value="1" /></label>
-            <label><input id="ttsEnabled" type="checkbox" checked /> TTS Enabled</label>
-            <label>TTS Path
-              <select id="ttsMode">
-                <option value="local">Local TTS</option>
-                <option value="cloud">Cloud TTS</option>
-                <option value="off">Off</option>
-              </select>
-            </label>
-            <label>TTS Provider
-              <select id="ttsProvider">
-                <option value="local">Local (no synth call)</option>
-                <option value="deepgram_aura">Deepgram Aura (Luna)</option>
-                <option value="openai">OpenAI TTS</option>
-              </select>
-            </label>
-            <label><input id="visionEnabled" type="checkbox" checked /> Vision Capture Enabled</label>
-            <label><input id="useRealCapture" type="checkbox" /> Use real capture endpoints</label>
-            <label>Vision Provider
-              <select id="visionProvider">
-                <option value="local">Local (moondream/ollama sidecar)</option>
-                <option value="openai">Cloud (OpenAI)</option>
-              </select>
-            </label>
-            <label>Vision Interval (seconds) <input id="visionIntervalSec" type="number" min="5" max="120" value="25" /></label>
-            <label>STT Provider
-              <select id="sttProvider">
-                <option value="local-whisper">Local Whisper (localhost)</option>
-                <option value="mock">Mock STT</option>
-                <option value="whispercpp">Whisper.cpp (custom endpoint)</option>
-                <option value="deepgram">Deepgram</option>
-                <option value="openai-whisper">OpenAI Whisper (cloud)</option>
-                <option value="gpt-4o-mini-transcribe">OpenAI GPT-4o mini transcribe (cloud)</option>
-              </select>
-            </label>
-            <label>STT endpoint <input id="sttEndpoint" type="text" value="http://127.0.0.1:7778/stt" /></label>
-            <label>Vision endpoint <input id="visionEndpoint" type="text" value="http://127.0.0.1:7778/vision-tags" /></label>
-            <label><input id="audioIntelligenceEnabled" type="checkbox" checked /> Audio Intelligence Enabled</label>
-          </div>
-        </details>
+          <details class="control-group workflow-section" id="sectionVerify" open>
+            <summary><span>4. Verify</span><span class="pill neutral">Status Cards</span></summary>
+            <h3>Runtime Verification</h3>
+            <div id="statusCards" class="status-cards"></div>
+            <label class="live-monitor-toggle"><input id="liveMonitorEnabled" type="checkbox" /> Enable live camera + voice monitor</label>
+            <p id="liveMonitorStatus" class="monitor-status">Live monitor disabled.</p>
+            <p id="sttCaptionStatus" class="monitor-status">Run Verify Microphone to start mic/STT check.</p>
+            <div id="sttCaptionPreview" class="caption-preview" aria-live="polite">No speech captured yet.</div>
+            <div class="live-monitor-grid">
+              <div class="live-frame" id="liveFrame">
+                <span id="liveBadge" class="live-badge">OFFLINE</span>
+                <video id="liveVideo" autoplay playsinline muted></video>
+              </div>
+              <canvas id="voiceMeter" width="280" height="80" aria-label="Voice meter"></canvas>
+            </div>
+            <ul id="deviceChecks">
+              <li>Mic/Camera checks not run yet.</li>
+            </ul>
 
-        <details class="control-group">
-          <summary>Safety, Moderation, and Security</summary>
-          <div class="grid">
-            <label>Safety drop policy
-              <select id="dropPolicy">
-                <option value="drop">Drop flagged content</option>
-                <option value="censor">Censor flagged content</option>
-              </select>
-            </label>
-            <label><input id="slowMode" type="checkbox" /> Slow Mode</label>
-            <label><input id="emoteOnly" type="checkbox" /> Emote-Only</label>
-            <label><input id="allowDiagnostics" type="checkbox" /> Allow diagnostics export</label>
-            <label><input id="allowNonLocalSidecarOverride" type="checkbox" /> Allow non-local sidecar override</label>
-            <label>Override reason <input id="overrideReason" type="text" placeholder="Required if override enabled" /></label>
-            <label class="eula"><input id="eulaAccepted" type="checkbox" /> I accept the simulation EULA/compliance terms</label>
-          </div>
-        </details>
+            <div class="dev-only" data-mode-visible="developer">
+              <pre id="runtimeSummary">Runtime status pending...</pre>
+              <p><strong>AI Health</strong> <span id="aiActiveModelLabel">(model: n/a)</span></p>
+              <pre id="aiHealthSummary">AI health pending...</pre>
+              <pre id="ttsHealthSummary">TTS health pending...</pre>
+              <pre id="sttHealthSummary">STT health pending...</pre>
+              <pre id="apiKeyHealthSummary">API key status pending...</pre>
+              <pre id="visionHealthSummary">Vision health pending...</pre>
+              <pre id="diagnosticsSummary"></pre>
+              <pre id="meta"></pre>
+            </div>
+          </details>
 
-        <details class="control-group">
-          <summary>Secrets + Maintenance</summary>
-          <div class="grid">
-            <label>Cloud API key <input id="cloudApiKey" type="password" placeholder="sk-..." /></label>
-            <label>Deepgram API key <input id="deepgramApiKey" type="password" placeholder="dg_..." /></label>
-          </div>
-          <div class="buttons">
-            <button id="saveCloudKey" type="button">Save Cloud Key</button>
-            <button id="saveDeepgramKey" type="button">Save Deepgram Key</button>
-            <button id="rebindAudio" type="button">Rebind Audio</button>
-            <button id="sidecarCancel" type="button">Cancel Sidecar Pull</button>
-            <button id="sidecarResume" type="button">Resume Sidecar Pull</button>
-            <button id="applyOverride" type="button">Apply Override</button>
-          </div>
-        </details>
+          <details class="control-group workflow-section" id="sectionSecurity" data-mode-visible="developer">
+            <summary><span>Safety, Moderation, and Security</span><span class="pill neutral">Developer</span></summary>
+            <div class="grid">
+              <label>Safety drop policy
+                <select id="dropPolicy">
+                  <option value="drop">Drop flagged content</option>
+                  <option value="censor">Censor flagged content</option>
+                </select>
+              </label>
+              <label><input id="slowMode" type="checkbox" /> Slow Mode</label>
+              <label><input id="emoteOnly" type="checkbox" /> Emote-Only</label>
+              <label><input id="allowDiagnostics" type="checkbox" /> Allow diagnostics export</label>
+              <label><input id="allowNonLocalSidecarOverride" type="checkbox" /> Allow non-local sidecar override</label>
+              <label>Override reason <input id="overrideReason" type="text" placeholder="Required if override enabled" /></label>
+              <label class="eula"><input id="eulaAccepted" type="checkbox" /> I accept the simulation EULA/compliance terms</label>
+            </div>
+            <div class="buttons">
+              <button id="applyOverride" type="button">Apply Override</button>
+            </div>
+          </details>
 
-        <div class="buttons sticky-actions">
-          <button id="save" type="button">Save Config</button>
-          <button id="start" type="button" class="primary">Start Simulation</button>
-          <button id="stop" type="button">Stop</button>
-          <button id="refreshStatus" type="button">Refresh Status</button>
-          <button id="verifyMic" type="button">Verify Microphone</button>
-          <button id="verifyCamera" type="button" disabled>Verify Camera</button>
-          <button id="openOverlayWindow" type="button">Open Transparent Chat Window</button>
+          <details class="control-group workflow-section" id="sectionSecrets" data-mode-visible="developer">
+            <summary><span>Secrets + Maintenance</span><span class="pill neutral">Developer</span></summary>
+            <div class="grid">
+              <label>Cloud API key <input id="cloudApiKey" type="password" placeholder="sk-..." /></label>
+              <label>Deepgram API key <input id="deepgramApiKey" type="password" placeholder="dg_..." /></label>
+            </div>
+            <div class="buttons">
+              <button id="saveCloudKey" type="button">Save Cloud Key</button>
+              <button id="saveDeepgramKey" type="button">Save Deepgram Key</button>
+              <button id="rebindAudio" type="button">Rebind Audio</button>
+              <button id="sidecarCancel" type="button">Cancel Sidecar Pull</button>
+              <button id="sidecarResume" type="button">Resume Sidecar Pull</button>
+            </div>
+          </details>
+
+          <section class="control-group sticky-run workflow-section" id="sectionRun" open>
+            <div class="run-header">
+              <h3>5. Run</h3>
+              <span class="pill neutral">Action</span>
+            </div>
+            <div class="buttons sticky-actions">
+              <button id="start" type="button" class="primary">Start Simulation</button>
+              <button id="stop" type="button">Stop</button>
+              <button id="save" type="button">Save Config</button>
+              <button id="refreshStatus" type="button">Refresh Status</button>
+              <button id="verifyMic" type="button">Verify Microphone</button>
+              <button id="verifyCamera" type="button" disabled>Verify Camera</button>
+              <button id="openOverlayWindow" type="button">Open Transparent Chat Window</button>
+            </div>
+            <p id="statusBanner" class="status-banner" aria-live="polite">Ready.</p>
+          </section>
         </div>
-        <p id="statusBanner" class="status-banner" aria-live="polite">Ready.</p>
-        <section class="control-group">
-          <h3>Runtime Verification</h3>
-          <pre id="runtimeSummary">Runtime status pending...</pre>
-          <p><strong>AI Health</strong> <span id="aiActiveModelLabel">(model: n/a)</span></p>
-          <pre id="aiHealthSummary">AI health pending...</pre>
-          <pre id="ttsHealthSummary">TTS health pending...</pre>
-          <pre id="sttHealthSummary">STT health pending...</pre>
-          <pre id="apiKeyHealthSummary">API key status pending...</pre>
-          <pre id="visionHealthSummary">Vision health pending...</pre>
-          <label class="live-monitor-toggle"><input id="liveMonitorEnabled" type="checkbox" /> Enable live camera + voice monitor</label>
-          <p id="liveMonitorStatus" class="monitor-status">Live monitor disabled.</p>
-          <p id="sttCaptionStatus" class="monitor-status">Run Verify Microphone to start mic/STT check.</p>
-          <div id="sttCaptionPreview" class="caption-preview" aria-live="polite">No speech captured yet.</div>
-          <div class="live-monitor-grid">
-            <video id="liveVideo" autoplay playsinline muted></video>
-            <canvas id="voiceMeter" width="280" height="80" aria-label="Voice meter"></canvas>
-          </div>
-          <ul id="deviceChecks">
-            <li>Mic/Camera checks not run yet.</li>
-          </ul>
-        </section>
-
-        <pre id="diagnosticsSummary"></pre>
-        <ul id="readinessList"></ul>
-        <pre id="meta"></pre>
       </section>
 
       <section class="panel overlay transparent-ready" id="overlay">
         <div class="watermark">Powered by StreamSim</div>
-        <h2>Overlay Preview</h2>
+        <div class="preview-header">
+          <h2>Live Preview</h2>
+          <div class="preview-stats">
+            <span id="previewViewerCount">👥 0</span>
+            <span id="previewAlerts">🔔 0</span>
+          </div>
+        </div>
+        <div class="preview-actions">
+          <button id="sendTestChat" type="button">Send Test Chat</button>
+          <button id="triggerTestDonation" type="button">Trigger Donation</button>
+          <button id="simulateViewerSpike" type="button">Simulate Viewer Spike</button>
+        </div>
         <div id="chat"></div>
       </section>
     </main>
+
+    <aside id="logsDrawer" class="logs-drawer" data-mode-visible="developer">
+      <button id="logsToggle" class="logs-toggle" type="button">Logs ▲</button>
+      <div id="logsPanel" class="logs-panel hidden">
+        <div class="logs-toolbar">
+          <select id="logFilter">
+            <option value="all">All</option>
+            <option value="system">System</option>
+            <option value="ai">AI</option>
+            <option value="stt">STT</option>
+            <option value="tts">TTS</option>
+            <option value="network">Network</option>
+          </select>
+          <input id="logSearch" type="text" placeholder="Search logs" />
+        </div>
+        <pre id="logsContent">No logs yet.</pre>
+      </div>
+    </aside>
 
     <script type="module" src="/app.js"></script>
   </body>

--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -1,119 +1,91 @@
 :root {
   color-scheme: dark;
-  --bg: #0f1014;
-  --panel: #1a1c22;
-  --panel-alt: rgba(0, 0, 0, 0.3);
+  --bg: #0d1017;
+  --panel: #151a24;
+  --panel-alt: rgba(15, 20, 32, 0.8);
   --text: #e9edf3;
-  --accent: #4ade80;
-  --accent-muted: rgba(74, 222, 128, 0.2);
-  --warning: #fbbf24;
-  --danger: #fb7185;
+  --muted: #94a3b8;
+  --accent: #60a5fa;
+  --accent-muted: rgba(96, 165, 250, 0.18);
+  --success: #22c55e;
+  --warning: #f59e0b;
+  --danger: #ef4444;
+  --inactive: #64748b;
 }
 
 * { box-sizing: border-box; font-family: Inter, ui-sans-serif, system-ui; }
-body { margin: 0; background: radial-gradient(circle at top, #161925, var(--bg)); color: var(--text); }
-.layout { display: grid; grid-template-columns: 420px 1fr; gap: 16px; padding: 16px; min-height: 100vh; }
-.panel { border: 1px solid #2d3345; border-radius: 14px; background: var(--panel); padding: 16px; }
-.controls { display: flex; flex-direction: column; gap: 12px; }
-.grid { display: grid; grid-template-columns: 1fr; gap: 12px; max-height: 70vh; overflow: auto; padding-right: 6px; }
-.compact-grid { grid-template-columns: 1fr 1fr; max-height: unset; }
-label { display: flex; flex-direction: column; gap: 6px; font-size: 0.9rem; }
-input, select, button { border-radius: 8px; border: 1px solid #3f475f; background: #12141c; color: var(--text); padding: 8px 10px; }
-input:focus-visible, select:focus-visible, button:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 1px;
+body { margin: 0; background: radial-gradient(circle at top, #1a2133, var(--bg)); color: var(--text); }
+.layout { display: grid; grid-template-columns: minmax(340px, 470px) 1fr; gap: 16px; padding: 16px; min-height: 100vh; }
+.panel { border: 1px solid #2d3748; border-radius: 14px; background: var(--panel); padding: 16px; }
+.controls { display: flex; flex-direction: column; gap: 12px; max-height: calc(100vh - 32px); overflow: auto; }
+
+.topbar { display: flex; justify-content: space-between; align-items: flex-start; gap: 12px; }
+.topbar h1 { margin: 0; font-size: 1.2rem; }
+.subtle { margin: 6px 0 0; color: var(--muted); font-size: 0.8rem; }
+.topbar-actions { display: flex; align-items: center; gap: 8px; }
+.mode-switch { display: flex; flex-direction: column; gap: 4px; font-size: 0.8rem; color: var(--muted); }
+
+.state-pill, .pill {
+  border-radius: 999px;
+  border: 1px solid #475569;
+  padding: 2px 9px;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
 }
-.buttons { display: flex; gap: 8px; margin-top: 10px; flex-wrap: wrap; }
+.state-pill.idle { color: #cbd5e1; border-color: #475569; }
+.state-pill.running { color: #bbf7d0; border-color: #15803d; }
+.state-pill.error { color: #fecaca; border-color: #b91c1c; }
+.pill.pending { color: #fde68a; border-color: #a16207; }
+.pill.complete { color: #bbf7d0; border-color: #15803d; }
+.pill.neutral { color: #bfdbfe; border-color: #1d4ed8; }
+
+.workflow-stack { display: flex; flex-direction: column; gap: 12px; }
+.control-group {
+  border: 1px solid #2f3a4f;
+  border-radius: 10px;
+  padding: 12px;
+  background: rgba(17, 23, 34, 0.85);
+}
+.control-group summary {
+  cursor: pointer;
+  font-weight: 700;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  list-style: none;
+}
+.control-group summary::-webkit-details-marker { display: none; }
+
+.grid { display: grid; gap: 12px; margin-top: 10px; }
+.compact-grid { grid-template-columns: 1fr; }
+label { display: flex; flex-direction: column; gap: 6px; font-size: 0.9rem; }
+input, select, button { border-radius: 8px; border: 1px solid #3f475f; background: #0f1420; color: var(--text); padding: 8px 10px; }
+input:focus-visible, select:focus-visible, button:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
 button { cursor: pointer; transition: border-color 140ms ease, background-color 140ms ease, opacity 140ms ease; }
 button:hover { border-color: var(--accent); }
 button:disabled { opacity: 0.6; cursor: progress; }
-button.primary { background: var(--accent-muted); border-color: #58c77d; }
-.overlay { position: relative; background: transparent; border-style: dashed; backdrop-filter: blur(1px); }
-.transparent-ready { box-shadow: inset 0 0 0 1px rgba(125, 211, 252, 0.3); }
-.watermark { position: absolute; top: 10px; right: 10px; opacity: 0.2; font-weight: 800; letter-spacing: 0.05em; }
-#chat { display: flex; flex-direction: column; gap: 8px; margin-top: 12px; }
-.chat-msg { background: var(--panel-alt); border: 1px solid #30384b; padding: 8px 10px; border-radius: 10px; line-height: 1.4; }
-.user { color: #7dd3fc; font-weight: 700; margin-right: 8px; }
-.donation { color: #facc15; margin-left: 8px; }
+button.primary { background: var(--accent-muted); border-color: #3b82f6; }
 
-.source-tag {
-  margin-left: 8px;
-  padding: 1px 6px;
-  border: 1px solid #334155;
-  border-radius: 999px;
-  font-size: 0.68rem;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  color: #cbd5e1;
-}
-pre { margin-top: 12px; background: #0c0e14; border: 1px solid #293145; border-radius: 8px; padding: 10px; font-size: 0.78rem; min-height: 130px; }
+.range-value { color: var(--muted); font-size: 0.8rem; }
 
 .onboarding-panel {
   border: 1px solid #334155;
   border-radius: 12px;
   padding: 12px;
+  margin-top: 10px;
   background: linear-gradient(180deg, rgba(22, 26, 36, 0.9), rgba(17, 20, 28, 0.9));
 }
-
-.onboarding-head {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 8px;
-}
-
-.onboarding-head h2 {
-  margin: 0;
-  font-size: 1.05rem;
-}
-
-.onboarding-steps {
-  margin: 10px 0;
-  padding-left: 20px;
-  color: #d1d5db;
-  font-size: 0.86rem;
-}
-
-.pill {
-  border-radius: 999px;
-  border: 1px solid #475569;
-  padding: 2px 8px;
-  font-size: 0.72rem;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-}
-
-.pill.pending { color: #fde68a; border-color: #a16207; }
-.pill.complete { color: #9ae6b4; border-color: #2f855a; }
-
-.control-group {
-  border: 1px solid #30384b;
-  border-radius: 10px;
-  padding: 10px;
-  background: #151922;
-}
-
-.control-group h3 {
-  margin: 0 0 10px;
-}
-
-.control-group summary {
-  cursor: pointer;
-  font-weight: 600;
-}
-
-.sticky-actions {
-  position: sticky;
-  bottom: 0;
-  padding-top: 8px;
-  background: linear-gradient(180deg, rgba(26, 28, 34, 0.8), rgba(26, 28, 34, 1));
-}
-
-.eula { padding: 8px; border: 1px solid #3f475f; border-radius: 8px; background: #10131b; }
+.onboarding-steps { margin: 8px 0; padding-left: 20px; color: #d1d5db; font-size: 0.84rem; }
 .wizard-inline-controls { display: grid; gap: 8px; }
+.eula { padding: 8px; border: 1px solid #3f475f; border-radius: 8px; background: #10131b; }
 
-#readinessList { margin-top: 10px; padding-left: 18px; }
-#readinessList li { margin-bottom: 6px; }
+.buttons { display: flex; gap: 8px; margin-top: 8px; flex-wrap: wrap; }
+.sticky-run { position: sticky; bottom: 0; z-index: 2; background: linear-gradient(180deg, rgba(21, 26, 36, 0.88), rgba(21, 26, 36, 1)); }
+.sticky-actions { margin-top: 8px; }
+.run-header { display: flex; justify-content: space-between; align-items: center; }
+
 .status-banner {
   margin: 12px 0 0;
   padding: 8px 10px;
@@ -122,116 +94,71 @@ pre { margin-top: 12px; background: #0c0e14; border: 1px solid #293145; border-r
   background: #0f172a;
   font-size: 0.85rem;
 }
-.status-banner.success { border-color: #2f855a; color: #9ae6b4; }
+.status-banner.success { border-color: #15803d; color: #bbf7d0; }
 .status-banner.warn { border-color: #a16207; color: #fde68a; }
-.status-banner.error { border-color: #be123c; color: #fecdd3; }
+.status-banner.error { border-color: #b91c1c; color: #fecaca; }
 
-@media (max-width: 1080px) {
-  .layout {
-    grid-template-columns: 1fr;
-  }
+.status-cards { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; margin-top: 10px; }
+.status-card { border: 1px solid #334155; border-radius: 8px; padding: 8px; background: #0f172a; }
+.status-card h4 { margin: 0 0 4px; font-size: 0.82rem; }
+.status-card p { margin: 0; font-size: 0.78rem; color: #cbd5e1; }
+.status-card.ok { border-color: #166534; }
+.status-card.warn { border-color: #92400e; }
+.status-card.error { border-color: #991b1b; }
+.status-card.inactive { border-color: #475569; }
 
-  .grid {
-    max-height: none;
-  }
-
-  .compact-grid {
-    grid-template-columns: 1fr;
-  }
-}
-
-
-#runtimeSummary {
-  min-height: 90px;
-  margin-top: 8px;
-}
-
-#deviceChecks {
-  margin: 8px 0 0;
-  padding-left: 18px;
-}
-
-.overlay-window {
-  background: transparent;
-}
-
-.overlay-root {
-  min-height: 100vh;
-  padding: 12px;
-}
-
-.overlay-root .overlay {
-  min-height: calc(100vh - 24px);
-  border-color: rgba(125, 211, 252, 0.6);
-}
-
-
-#aiHealthSummary {
-  min-height: 82px;
-  margin-top: 8px;
-}
-
-.live-monitor-toggle {
-  margin-top: 8px;
-  padding: 8px;
-  border: 1px solid #334155;
-  border-radius: 8px;
-  background: #0f172a;
-}
-
-.monitor-status {
-  margin: 8px 0;
-  font-size: 0.85rem;
-  color: #fde68a;
-}
+.live-monitor-toggle { margin-top: 8px; padding: 8px; border: 1px solid #334155; border-radius: 8px; background: #0f172a; }
+.monitor-status { margin: 8px 0; font-size: 0.85rem; color: #fde68a; }
 .monitor-status.ok { color: #86efac; }
 .monitor-status.error { color: #fda4af; }
-
-.live-monitor-grid {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 8px;
-}
-
-#liveVideo {
-  width: 100%;
-  max-height: 180px;
-  border-radius: 8px;
-  border: 1px solid #334155;
-  background: #020617;
-  object-fit: cover;
-}
-
-#voiceMeter {
-  width: 100%;
-  border-radius: 8px;
-  border: 1px solid #334155;
-  background: #020617;
-}
-
-#ttsHealthSummary {
-  min-height: 82px;
-  margin-top: 8px;
-}
-
-#sttHealthSummary {
-  min-height: 82px;
-  margin-top: 8px;
-}
-
-#visionHealthSummary {
-  min-height: 82px;
-  margin-top: 8px;
-}
-
 .caption-preview {
-  min-height: 56px;
-  margin-bottom: 8px;
-  border: 1px solid #334155;
-  border-radius: 8px;
-  background: #020617;
-  padding: 8px 10px;
-  font-size: 0.84rem;
-  color: #cbd5e1;
-  line-height: 1.35;
+  min-height: 56px; margin-bottom: 8px; border: 1px solid #334155; border-radius: 8px; background: #020617;
+  padding: 8px 10px; font-size: 0.84rem; color: #cbd5e1; line-height: 1.35;
+}
+.live-monitor-grid { display: grid; grid-template-columns: 1fr; gap: 8px; }
+.live-frame { position: relative; border-radius: 8px; overflow: hidden; border: 1px solid #334155; }
+.live-frame.active { box-shadow: 0 0 0 1px rgba(34, 197, 94, 0.7), 0 0 24px rgba(34, 197, 94, 0.15); }
+.live-badge {
+  position: absolute; top: 8px; left: 8px; z-index: 1; padding: 2px 8px; border-radius: 999px;
+  font-size: 0.7rem; border: 1px solid #475569; background: rgba(2, 6, 23, 0.85);
+}
+.live-badge.live { color: #fecaca; border-color: #dc2626; background: rgba(127, 29, 29, 0.6); }
+
+#liveVideo { width: 100%; max-height: 210px; background: #020617; object-fit: cover; display: block; }
+#voiceMeter { width: 100%; border-radius: 8px; border: 1px solid #334155; background: #020617; }
+#deviceChecks { margin: 8px 0 0; padding-left: 18px; font-size: 0.85rem; }
+
+.overlay { position: relative; background: transparent; border-style: dashed; backdrop-filter: blur(1px); }
+.transparent-ready { box-shadow: inset 0 0 0 1px rgba(125, 211, 252, 0.3); }
+.watermark { position: absolute; top: 10px; right: 10px; opacity: 0.2; font-weight: 800; letter-spacing: 0.05em; }
+.preview-header { display: flex; align-items: center; justify-content: space-between; gap: 10px; }
+.preview-header h2 { margin: 0; }
+.preview-stats { display: flex; gap: 10px; color: #bfdbfe; font-size: 0.86rem; }
+.preview-actions { margin-top: 10px; display: flex; flex-wrap: wrap; gap: 8px; }
+#chat { display: flex; flex-direction: column; gap: 8px; margin-top: 12px; }
+.chat-msg { background: var(--panel-alt); border: 1px solid #30384b; padding: 8px 10px; border-radius: 10px; line-height: 1.4; animation: pulseIn 280ms ease; }
+.user { color: #7dd3fc; font-weight: 700; margin-right: 8px; }
+.donation { color: #facc15; margin-left: 8px; }
+.source-tag {
+  margin-left: 8px; padding: 1px 6px; border: 1px solid #334155; border-radius: 999px; font-size: 0.68rem;
+  letter-spacing: 0.04em; text-transform: uppercase; color: #cbd5e1;
+}
+
+pre { margin-top: 8px; background: #0c0e14; border: 1px solid #293145; border-radius: 8px; padding: 10px; font-size: 0.75rem; min-height: 80px; }
+
+.logs-drawer { position: fixed; right: 16px; bottom: 16px; width: min(620px, 90vw); }
+.logs-toggle { width: 100%; }
+.logs-panel { margin-top: 8px; border: 1px solid #334155; border-radius: 10px; background: #0b1220; padding: 10px; }
+.logs-panel.hidden { display: none; }
+.logs-toolbar { display: flex; gap: 8px; margin-bottom: 8px; }
+#logsContent { max-height: 220px; overflow: auto; min-height: 160px; margin: 0; }
+
+[data-ui-mode="operator"] [data-mode-visible="developer"] { display: none !important; }
+
+@keyframes pulseIn { from { transform: translateY(4px); opacity: 0.2; } to { transform: translateY(0); opacity: 1; } }
+
+@media (max-width: 1080px) {
+  .layout { grid-template-columns: 1fr; }
+  .status-cards { grid-template-columns: 1fr; }
+  .logs-drawer { right: 10px; left: 10px; width: auto; }
 }


### PR DESCRIPTION
### Motivation
- Move the Control Center from a flat feature-based layout into a guided, step-based workflow (Setup → Configure → Connect → Verify → Run) to improve clarity and reduce cognitive load.
- Provide a compact Operator view for product users while preserving the full Developer view for debugging and observability without duplicating state or changing backend behavior.
- Surface high-signal status (system badge, status cards, connect pill) and make verification/monitoring easier to scan at-a-glance.

### Description
- Reworked the control UI markup and layout by updating `src/public/index.html` to an accordion-based workflow, adding a global `Mode` selector, runtime status badge, status cards, preview test controls, and a dev-only logs drawer. 
- Implemented client-side wiring in `src/public/app.js` including UI mode persistence (`localStorage`), keyboard shortcuts (`Cmd/Ctrl + D` to toggle Developer mode and `Cmd/Ctrl + L` to open logs), in-browser logging/filtering, status-card rendering, preview controls (test chat, donation, viewer spike), live monitor LIVE/OFFLINE badge, and non-breaking range label helpers. 
- Restyled the UI in `src/public/styles.css` introducing the guided visual system (accent color, spacing, status-card styles, live-badge and active frame visuals) while keeping existing control IDs and interaction logic intact. 
- Preserves all backend-facing contracts: API endpoints, state schema, event pipeline, and simulation logic were not changed (UI-only presentation layer changes).

### Testing
- Ran `npm test -- --runInBand` which failed due to an unsupported Vitest option (unknown `--runInBand`).
- Ran the project test suite with `npm test` and verified the full suite succeeded: all tests passed (`110 tests, 110 passed`).
- Verified the UI boot and runtime-status refresh logic via existing tests that check presence of runtime verification elements and device/monitor wiring (no tests were modified).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9ea9709d08324a47a1aff14d877ea)