### PR TITLE
Vision freshness gating, idle rotation, token budget, dedupe, and subtle source-tag UI tweak

### DIFF
--- a/src/capture/deviceCapturePipeline.ts
+++ b/src/capture/deviceCapturePipeline.ts
@@ -79,6 +79,7 @@ export class DeviceCapturePipeline {
       transcript,
       tone,
       visionTags,
+      visionCapturedAt: this.lastVisionSample ? new Date(this.lastVisionSample.capturedAt).toISOString() : undefined,
       vibe: this.lastIntelligenceSample?.vibe,
       topic: this.lastIntelligenceSample?.topic,
       intent: this.lastIntelligenceSample?.intent,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -96,6 +96,7 @@ export interface StreamContext {
   transcript: string;
   tone: ToneSnapshot;
   visionTags: string[];
+  visionCapturedAt?: string;
   vibe?: SimulatedVibe;
   topic?: string;
   intent?: string;

--- a/src/llm/realInferenceProvider.ts
+++ b/src/llm/realInferenceProvider.ts
@@ -168,9 +168,15 @@ function systemPromptForPayload(payload: PromptPayload): string {
   const questionDirective = transcript && /\?/.test(transcript)
     ? "The transcript includes a question; at least one message must directly answer or acknowledge that question."
     : "If no question is present in the transcript, avoid inventing one.";
+  const visionAgeMs = payload.context.visionCapturedAt ? Date.now() - Date.parse(payload.context.visionCapturedAt) : Number.POSITIVE_INFINITY;
+  const visualQuestionDetected = /\b(look|see|show|camera|cam|color|wearing|shirt|hat|hands?|fingers?|peace sign|how many)\b/i.test(transcript);
+  const staleVision = !Number.isFinite(visionAgeMs) || visionAgeMs > 12_000;
   const visionDirective = payload.context.visionTags.length
     ? `Vision state: context.visionTags is populated (${payload.context.visionTags.map((tag) => `"${tag}"`).join(", ")}). Reference concrete tag details directly and do not invent unseen attributes.`
     : "Vision state: context.visionTags is empty, so you are BLIND right now. Do not invent visuals; if asked visual questions, clearly say the cam/feed is not visible.";
+  const visionFreshnessDirective = visualQuestionDetected && staleVision
+    ? "Visual question detected but the latest vision sample is stale or missing. Do not guess. At least one message should ask to wait for a fresh cam update."
+    : "Vision freshness looks usable for current tick.";
   const situationalTags = payload.situationalTags.length ? payload.situationalTags.join(", ") : "none";
   const behavioralModes = payload.behavioralModes.length ? payload.behavioralModes.join(", ") : "default";
   const vibeDirective = payload.context.vibe
@@ -198,6 +204,7 @@ function systemPromptForPayload(payload: PromptPayload): string {
     transcriptDirective,
     questionDirective,
     visionDirective,
+    visionFreshnessDirective,
     vibeDirective,
     `Situational tags detected by orchestrator metadata: ${situationalTags}`,
     `Behavioral modes selected by orchestrator: ${behavioralModes}`,
@@ -225,6 +232,8 @@ function systemPromptForPayload(payload: PromptPayload): string {
     "Do not feel obligated to acknowledge every streamer line; realistic chats often drift into side chatter.",
     "SILENCE BEHAVIOR: if the streamer is silent, stay chill like a waiting room, keep it light with 'lurk' or a short on-topic question.",
     "During silence, first continue answering the last question asked, then use topic-relevant emotes/slang.",
+    "Idle-topic rotation examples for short silence: queue check, setup tweak, next map guess, controller check, warmup routine, clip timestamp callout, hydration reminder, scoreboard prediction.",
+    "Silence repetition guard: avoid repeating the exact phrases 'morning vibes' or 'keep it chill' in nearby messages; rotate idle openers.",
     "Hard ban phrases: never say 'pick a lane' or 'pick a topic'.",
     "Do not accuse the streamer of ghosting/vanishing/disappearing after short silence; assume they are still present unless explicitly leaving.",
     "Do NOT start random food debates unless streamer silence clearly lasts over 2 minutes.",
@@ -285,6 +294,7 @@ function buildModelFacingPayload(payload: PromptPayload): Record<string, unknown
         pace: describePace(payload.context.tone.paceWpm)
       },
       visionTags: payload.context.visionTags,
+      visionCapturedAt: payload.context.visionCapturedAt ?? null,
       vibe: payload.context.vibe ?? "chill",
       topic: payload.context.topic ?? "general",
       intent: payload.context.intent ?? "none",
@@ -318,6 +328,11 @@ function isRetryableCloudFailure(message: string): boolean {
 
 function isResponseFormatSchemaFailure(status: number, detail: string): boolean {
   return status === 400 && /invalid schema for response_format|required/i.test(detail);
+}
+
+function completionTokenCap(requestedMessageCount: number): number {
+  const safeCount = Math.max(2, Math.min(8, Math.floor(requestedMessageCount || 2)));
+  return Math.max(120, Math.min(240, 40 + safeCount * 20));
 }
 
 export class HybridInferenceProvider implements InferenceProvider {
@@ -441,12 +456,14 @@ export class HybridInferenceProvider implements InferenceProvider {
         model: string;
         messages: Array<{ role: "system" | "user"; content: string }>;
         response_format?: ReturnType<typeof openAiResponseSchema>;
+        max_completion_tokens?: number;
       } = {
         model,
         messages
       };
       if (this.mode === "openai") {
         baseBody.response_format = openAiResponseSchema(payload.requestedMessageCount);
+        baseBody.max_completion_tokens = completionTokenCap(payload.requestedMessageCount);
       }
 
       const requestVariants =

--- a/src/public/app.js
+++ b/src/public/app.js
@@ -1415,7 +1415,10 @@ function renderIncomingMessages(messages) {
 
     const source = document.createElement("span");
     source.className = "source-tag";
-    source.textContent = msg.source ?? "unknown";
+    source.textContent = "ⓘ";
+    source.title = `message source: ${msg.source ?? "unknown"}`;
+    source.setAttribute("aria-label", source.title);
+    source.dataset.source = msg.source ?? "unknown";
     item.append(source);
 
     if (msg.donationCents) {

--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -140,9 +140,21 @@ button.primary { background: var(--accent-muted); border-color: #3b82f6; }
 .user { color: #7dd3fc; font-weight: 700; margin-right: 8px; }
 .donation { color: #facc15; margin-left: 8px; }
 .source-tag {
-  margin-left: 8px; padding: 1px 6px; border: 1px solid #334155; border-radius: 999px; font-size: 0.68rem;
-  letter-spacing: 0.04em; text-transform: uppercase; color: #cbd5e1;
+  margin-left: 8px;
+  width: 16px;
+  height: 16px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid #334155;
+  border-radius: 999px;
+  font-size: 0.58rem;
+  color: #94a3b8;
+  opacity: 0.45;
+  cursor: help;
+  transition: opacity 120ms ease, color 120ms ease, border-color 120ms ease;
 }
+.chat-msg:hover .source-tag { opacity: 1; color: #e2e8f0; border-color: #64748b; }
 
 pre { margin-top: 8px; background: #0c0e14; border: 1px solid #293145; border-radius: 8px; padding: 10px; font-size: 0.75rem; min-height: 80px; }
 

--- a/src/services/modSimController.ts
+++ b/src/services/modSimController.ts
@@ -94,10 +94,11 @@ export class ModSimController {
     const deEchoedMessages = this.isReadingChat(context.transcript, context.recentChatHistory)
       ? this.rewriteForReadingChat(messages)
       : this.applyAntiEchoConstraint(messages, context.transcript);
-    const diverseMessages = this.enforceDiversityRules(deEchoedMessages, payload.behavioralModes);
+    const diverseMessages = this.enforceDiversityRules(deEchoedMessages, payload.behavioralModes, payload.context.recentChatHistory);
     const personaLocked = this.enforcePersonaSyntax(diverseMessages);
     const scrubbedMessages = this.postFlight(personaLocked, { brainRot: payload.persona !== "supportive" });
-    return this.identityManager.assignToMessages(scrubbedMessages);
+    const dedupedPostFlight = this.enforceBatchUniqueness(scrubbedMessages);
+    return this.identityManager.assignToMessages(dedupedPostFlight);
   }
 
   public postFlight(messages: ChatMessage[], options?: { brainRot?: boolean }): ChatMessage[] {
@@ -137,7 +138,7 @@ export class ModSimController {
     return context;
   }
 
-  public enforceDiversityRules(messages: ChatMessage[], behavioralModes: string[]): ChatMessage[] {
+  public enforceDiversityRules(messages: ChatMessage[], behavioralModes: string[], recentChatHistory: string[] = []): ChatMessage[] {
     const slangCooldownWords = ["lowkey", "ngl", "bet", "cooked", "fr"];
     const slangAlternatives: Record<string, string[]> = {
       lowkey: ["ngl", "tbh", "honestly"],
@@ -199,13 +200,29 @@ export class ModSimController {
     const seen = new Set<string>();
     const fallbackReplies = ["new take pls", "same line again??", "switch it up bro", "different angle pls"];
     deduped.forEach((message, index) => {
-      const key = message.text.toLowerCase().replace(/\s+/g, " ").trim();
+      const key = this.normalizedDiversityKey(message.text);
       if (!key) return;
       if (seen.has(key)) {
         message.text = fallbackReplies[index % fallbackReplies.length];
         return;
       }
       seen.add(key);
+    });
+
+    const recentlyUsedIdlePhrases = [
+      "morning vibes",
+      "keep it chill",
+      "keep it light",
+      "waiting room energy",
+      "just lurking"
+    ];
+    const historyJoined = recentChatHistory.join(" ").toLowerCase();
+    deduped.forEach((message, index) => {
+      const normalized = message.text.toLowerCase().replace(/\s+/g, " ").trim();
+      if (recentlyUsedIdlePhrases.some((phrase) => normalized.includes(phrase) && historyJoined.includes(phrase))) {
+        const replacements = ["queue check?", "next map?", "scoreboard soon?", "clip that setup", "hydration break?"];
+        message.text = replacements[index % replacements.length];
+      }
     });
 
     const maxWords = 4;
@@ -232,9 +249,13 @@ export class ModSimController {
   public applyAntiEchoConstraint(messages: ChatMessage[], transcript: string): ChatMessage[] {
     const anchors = this.transcriptAnchorTerms(transcript);
     if (!anchors.length) return messages;
+    const transcriptHasQuestion = transcript.includes("?");
 
     const filtered = messages.filter((message) => {
       const lowered = message.text.toLowerCase();
+      if (transcriptHasQuestion && this.looksLikeDirectAnswer(lowered)) {
+        return true;
+      }
       return anchors.every((token) => !lowered.includes(token));
     });
 
@@ -321,5 +342,32 @@ export class ModSimController {
         .map((token) => token.trim())
         .filter((token) => token.length >= 4)
     );
+  }
+
+  private normalizedDiversityKey(text: string): string {
+    return text
+      .toLowerCase()
+      .replace(/\p{Extended_Pictographic}/gu, "")
+      .replace(/[^a-z0-9\s']/g, " ")
+      .replace(/\s+/g, " ")
+      .trim();
+  }
+
+  private looksLikeDirectAnswer(text: string): boolean {
+    return /\b(yes|yep|no|nah|idk|cant|can't|cannot|wait)\b/.test(text) || /\b(one|two|three|four|five|six|seven|eight|nine|ten|\d+)\b/.test(text);
+  }
+
+  private enforceBatchUniqueness(messages: ChatMessage[]): ChatMessage[] {
+    const seen = new Set<string>();
+    const replacements = ["new angle bro", "different read", "switching lanes", "not the same line", "fresh take only"];
+    return messages.map((message, index) => {
+      const key = this.normalizedDiversityKey(message.text);
+      if (!key) return message;
+      if (!seen.has(key)) {
+        seen.add(key);
+        return message;
+      }
+      return { ...message, text: replacements[index % replacements.length] };
+    });
   }
 }

--- a/tests/antiEcho.test.ts
+++ b/tests/antiEcho.test.ts
@@ -244,4 +244,58 @@ describe("anti-echo constraint", () => {
     expect(third.transcript).toBe("same line from streamer");
     expect(fourth.transcript).toBe("");
   });
+
+  it("allows direct short answers on question transcripts even with overlap tokens", () => {
+    const orchestrator = makeOrchestrator();
+    const input: ChatMessage[] = [
+      {
+        id: "1",
+        username: "user1",
+        text: "2 fingers",
+        emotes: [],
+        donationCents: null,
+        ttsText: null,
+        createdAt: new Date().toISOString()
+      }
+    ];
+
+    const filtered = (orchestrator as any).applyAntiEchoConstraint(input, "how many fingers am i holding up?");
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].text).toContain("2");
+  });
+
+  it("deduplicates repeated lines after post-flight cleanup", () => {
+    const orchestrator = makeOrchestrator();
+    const context = {
+      transcript: "",
+      tone: { volumeRms: 0.2, paceWpm: 110 },
+      visionTags: [],
+      recentChatHistory: [],
+      timestamp: new Date().toISOString()
+    };
+    const payload = {
+      persona: "neutral" as const,
+      bias: "split" as const,
+      emoteOnly: false,
+      viewerCount: 100,
+      streamTopic: "Just Chatting",
+      context,
+      situationalTags: [],
+      behavioralModes: ["default"],
+      requestedMessageCount: 3,
+      personaCalibration: { positivity: 0.5, sarcasm: 0.5, contrarianism: 0.5 },
+      providerConditioning: { providerClass: "mock", expressiveness: 0.5, volatility: 0.5, policyStrictness: 0.5 }
+    };
+
+    const processed = (orchestrator as any).modSim.process(
+      [
+        { id: "1", username: "a", text: "bro what was that 💀", emotes: [], donationCents: null, ttsText: null, createdAt: new Date().toISOString() },
+        { id: "2", username: "b", text: "bro what was that 💀", emotes: [], donationCents: null, ttsText: null, createdAt: new Date().toISOString() },
+        { id: "3", username: "c", text: "bro what was that 💀", emotes: [], donationCents: null, ttsText: null, createdAt: new Date().toISOString() }
+      ],
+      payload
+    );
+    const normalized = processed.map((msg: ChatMessage) => msg.text.toLowerCase().replace(/\s+/g, " ").trim());
+    expect(new Set(normalized).size).toBeGreaterThan(1);
+  });
 });

--- a/tests/integrationRouting.test.ts
+++ b/tests/integrationRouting.test.ts
@@ -240,7 +240,11 @@ describe("hybrid routing and failover", () => {
         const parsed = JSON.parse(body);
         expect(parsed.messages[1].role).toBe("user");
         expect(parsed.max_tokens).toBeUndefined();
-        expect(parsed.max_completion_tokens).toBeUndefined();
+        if (req.headers["x-streamsim-provider"] === "groq") {
+          expect(parsed.max_completion_tokens).toBeUndefined();
+        } else {
+          expect(parsed.max_completion_tokens).toBeGreaterThanOrEqual(120);
+        }
         expect(parsed.temperature).toBeUndefined();
         res.writeHead(200, { "Content-Type": "application/json" });
         res.end(JSON.stringify({ choices: [{ message: { content: '{"messages":[]}' } }] }));
@@ -320,7 +324,7 @@ describe("hybrid routing and failover", () => {
         const parsed = JSON.parse(body);
         expect(parsed.model).toBe("gpt-5-mini");
         expect(parsed.max_tokens).toBeUndefined();
-        expect(parsed.max_completion_tokens).toBeUndefined();
+        expect(parsed.max_completion_tokens).toBeGreaterThanOrEqual(120);
         expect(parsed.temperature).toBeUndefined();
         res.writeHead(200, { "Content-Type": "application/json" });
         res.end(JSON.stringify({ choices: [{ message: { content: '{"messages":[]}' } }] }));

--- a/tests/pipeline.test.ts
+++ b/tests/pipeline.test.ts
@@ -169,7 +169,7 @@ describe("inference failure explanation", () => {
 });
 
 describe("cloud generation hardening", () => {
-  it("omits explicit max_completion_tokens for cloud generation compatibility", async () => {
+  it("sets a bounded max_completion_tokens budget for cloud generation", async () => {
     process.env.STREAMSIM_CLOUD_API_KEY = "test-key";
     const provider = new HybridInferenceProvider("openai");
     const fetchMock = vi.fn(async () => ({
@@ -187,7 +187,8 @@ describe("cloud generation hardening", () => {
 
     await provider.generate(payload, defaultConfig);
     const body = JSON.parse(String(fetchMock.mock.calls[0][1]?.body));
-    expect(body.max_completion_tokens).toBeUndefined();
+    expect(body.max_completion_tokens).toBeGreaterThanOrEqual(120);
+    expect(body.max_completion_tokens).toBeLessThanOrEqual(240);
     vi.unstubAllGlobals();
   });
 


### PR DESCRIPTION
### Motivation

- Prevent viewers from answering stale visual questions by letting the pipeline reason about when the last camera sample was captured. 
- Reduce rapid repetition of a few idle phrases during short silences and provide more varied short idle-topic prompts. 
- Avoid truncated/incomplete cloud responses for larger batches by applying a bounded token budget to cloud requests. 
- Stop same-line triple-spam and make the `real-inference` source label less visually noisy in the UI.

### Description

- Added `visionCapturedAt` to the `StreamContext` and populate it from the latest vision sample in `DeviceCapturePipeline.getContext`. 
- Exposed `visionCapturedAt` into the model-facing payload and updated the cloud/system prompt in `realInferenceProvider` to detect likely visual questions, check freshness (stale if >12s), and instruct the model to wait for a fresh camera update when appropriate; also added short `Idle-topic rotation` guidance and a silence repetition guard. 
- Introduced a bounded cloud completion token cap via `completionTokenCap(requestedMessageCount)` and set `max_completion_tokens` on OpenAI request bodies (range ~120–240 depending on batch size) in `HybridInferenceProvider`. 
- Hardened ModSim dedupe/diversity: pass `recentChatHistory` into `enforceDiversityRules`, normalize diversity keys, avoid reusing recent idle phrases, allow short direct answers on question transcripts in `applyAntiEchoConstraint`, and add a post-flight `enforceBatchUniqueness` pass to reduce identical messages. 
- Made the message source less prominent in UI by rendering a compact `ⓘ` source icon with a hover tooltip and updated styles in `src/public/app.js` and `src/public/styles.css`. 
- Updated and added tests to assert token-budget behavior, cloud routing expectations, question-safe anti-echo handling, and post-flight dedupe behavior (`tests/pipeline.test.ts`, `tests/integrationRouting.test.ts`, `tests/antiEcho.test.ts`).

### Testing

- Built the project with `npm run build` and the TypeScript compile completed successfully. 
- Ran unit/integration tests with `npm run test -- tests/antiEcho.test.ts tests/pipeline.test.ts tests/integrationRouting.test.ts tests/uiRuntimeVerification.test.ts` and all executed tests passed. 
- Targeted assertions added to tests cover `max_completion_tokens` bounds, anti-echo allowance for short direct answers, and post-flight batch deduplication, and those assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca1063e62483248da46b4b4022eae6)