### PR TITLE
Refine anti-echo, vision synchronization, and batch/token budgeting

### DIFF
--- a/src/config/runtimeConfig.ts
+++ b/src/config/runtimeConfig.ts
@@ -37,7 +37,7 @@ export const defaultConfig: SimulationConfig = {
     localEndpoint: "http://127.0.0.1:11434",
     localModel: "llama3.1:8b-instruct-q4_K_M",
     cloudEndpoint: "https://api.openai.com/v1/chat/completions",
-    cloudModel: "gpt-5.4-nano-2026-03-17",
+    cloudModel: "gpt-5.4-mini-2026-03-17",
     requestTimeoutMs: 30000,
     maxRetries: 1
   },

--- a/src/llm/realInferenceProvider.ts
+++ b/src/llm/realInferenceProvider.ts
@@ -193,7 +193,8 @@ function systemPromptForPayload(payload: PromptPayload): string {
     // Primacy zone: engine rules
     `Return strict JSON only: {"messages":[{"text":"string","emotes":["string"],"donationCents"?:number|null,"ttsText"?:string|null}]}. Never include usernames.`,
     fishingDirective,
-    `messages must be an array with exactly ${payload.requestedMessageCount} items (valid batch range is 2 to 8 based on viewerCount).`,
+    `messages must be an array with exactly ${payload.requestedMessageCount} items (valid batch range is 5 to 11 based on viewerCount).`,
+    "Each message text MUST stay under 10 words.",
     "STRICT COMMAND OVERRIDE (highest priority): if streamer says 'drop [X]' or 'type [X]' or 'spam [X]', message 1 and message 2 MUST be exactly [X] with no extra words, punctuation, or emojis.",
     "COMMAND PRECEDENCE: when command override triggers, it cancels contrast, question-answer, anti-echo, and diversity constraints for message 1/message 2.",
     "GROUPTHINK RULE: during a drop/type/spam command, diversity is disabled and both first messages must output the same exact token.",
@@ -331,8 +332,8 @@ function isResponseFormatSchemaFailure(status: number, detail: string): boolean 
 }
 
 function completionTokenCap(requestedMessageCount: number): number {
-  const safeCount = Math.max(2, Math.min(8, Math.floor(requestedMessageCount || 2)));
-  return Math.max(120, Math.min(240, 40 + safeCount * 20));
+  const safeCount = Math.max(5, Math.min(11, Math.floor(requestedMessageCount || 5)));
+  return Math.max(150, Math.min(280, 70 + safeCount * 18));
 }
 
 export class HybridInferenceProvider implements InferenceProvider {

--- a/src/pipeline/promptBuilder.ts
+++ b/src/pipeline/promptBuilder.ts
@@ -90,7 +90,7 @@ function mapBehavioralModes(situationalTags: string[]): string[] {
 }
 
 export function buildPromptPayload(config: SimulationConfig, context: StreamContext): PromptPayload {
-  const requestedMessageCount = Math.max(2, Math.min(8, Math.floor(Math.sqrt(config.viewerCount) / 18) + 1));
+  const requestedMessageCount = Math.max(5, Math.min(11, Math.floor(Math.sqrt(config.viewerCount) / 14) + 4));
   const situationalTags = detectSituationalTags(context);
   const behavioralModes = mapBehavioralModes(situationalTags);
 

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -94,7 +94,7 @@
               <label>Local endpoint <input id="localEndpoint" type="text" value="http://127.0.0.1:11434" /></label>
               <label>Local model <input id="localModel" type="text" value="llama3.1:8b-instruct-q4_K_M" /></label>
               <label>Cloud endpoint <input id="cloudEndpoint" type="text" value="https://api.openai.com/v1/chat/completions" /></label>
-              <label>Cloud model <input id="cloudModel" type="text" value="gpt-5.4-nano-2026-03-17" /></label>
+              <label>Cloud model <input id="cloudModel" type="text" value="gpt-5.4-mini-2026-03-17" /></label>
               <label>Request timeout ms <input id="requestTimeoutMs" type="number" min="1000" max="120000" value="30000" /></label>
               <label>Max retries <input id="maxRetries" type="number" min="0" max="5" value="1" /></label>
               <label><input id="ttsEnabled" type="checkbox" checked /> TTS Enabled</label>

--- a/src/services/modSimController.ts
+++ b/src/services/modSimController.ts
@@ -2,6 +2,32 @@ import { ChatMessage, PromptPayload, SimulationConfig, StreamContext } from "../
 import { IdentityManager } from "./identityManager.js";
 
 const DEFAULT_SLANG_TERMS = ["cooked", "ratio", "l", "fr", "ngl", "lowkey"];
+const CONTRARIAN_REGISTRY = [
+  "nah that ain't it",
+  "cap detected instantly",
+  "who told you that",
+  "chat not buying this",
+  "wild take ngl",
+  "bro missed hard",
+  "this angle is cooked",
+  "hard disagree right now",
+  "that logic is fried",
+  "stop the glaze immediately",
+  "you reaching for that one",
+  "we not co-signing this",
+  "this ain't convincing",
+  "hater mode activated",
+  "ratio energy detected",
+  "this read is off",
+  "nah switch the script",
+  "not the move chief",
+  "that take fell flat",
+  "major side-eye on that",
+  "press x to doubt",
+  "who let bro cook",
+  "nah this is delusion",
+  "we need a better take"
+];
 
 export class ModSimController {
   private readonly transcriptSeenCounter = new Map<string, { count: number; lastSeenAt: number }>();
@@ -55,6 +81,7 @@ export class ModSimController {
     return [
       `Return strict JSON only: {"messages":[{"text":"string","emotes":["string"],"donationCents":number|null,"ttsText":string|null}]}.`,
       `messages must contain exactly ${payload.requestedMessageCount} entries.`,
+      "Each message text MUST be under 10 words. Quality over quantity.",
       `Topic lock: ${streamTopic}.`,
       transcript
         ? `Highest priority: react to latest streamer words: "${transcriptTail}".`
@@ -66,6 +93,7 @@ export class ModSimController {
       primacyDirective,
       chaosDirective,
       degeneracyDirective,
+      "DO NOT mirror the streamer's opening phrase; never start with the transcript's last 2 words.",
       bannedTermDirective,
       "Never say: 'the viewer says', 'I am an AI', or explain system internals.",
       "Keep messages short and non-repetitive."
@@ -94,7 +122,9 @@ export class ModSimController {
     const deEchoedMessages = this.isReadingChat(context.transcript, context.recentChatHistory)
       ? this.rewriteForReadingChat(messages)
       : this.applyAntiEchoConstraint(messages, context.transcript);
-    const diverseMessages = this.enforceDiversityRules(deEchoedMessages, payload.behavioralModes, payload.context.recentChatHistory);
+    const nonMirroredMessages = this.stripBannedStarters(deEchoedMessages, context.transcript);
+    const starterSafeMessages = nonMirroredMessages.length ? nonMirroredMessages : deEchoedMessages;
+    const diverseMessages = this.enforceDiversityRules(starterSafeMessages, payload.behavioralModes, payload.context.recentChatHistory);
     const personaLocked = this.enforcePersonaSyntax(diverseMessages);
     const scrubbedMessages = this.postFlight(personaLocked, { brainRot: payload.persona !== "supportive" });
     const dedupedPostFlight = this.enforceBatchUniqueness(scrubbedMessages);
@@ -256,7 +286,10 @@ export class ModSimController {
       if (transcriptHasQuestion && this.looksLikeDirectAnswer(lowered)) {
         return true;
       }
-      return anchors.every((token) => !lowered.includes(token));
+      const overlapCount = anchors.filter((token) => lowered.includes(token)).length;
+      if (overlapCount <= 1) return true;
+      if (anchors.length >= 5 && overlapCount <= 2) return true;
+      return false;
     });
 
     if (filtered.length > 0) return filtered;
@@ -267,7 +300,7 @@ export class ModSimController {
         ...seed,
         id: seed?.id ?? `${Date.now()}-anti-echo`,
         createdAt: seed?.createdAt ?? new Date().toISOString(),
-        text: "bro what was that 💀",
+        text: CONTRARIAN_REGISTRY[Math.floor(Math.random() * CONTRARIAN_REGISTRY.length)],
         emotes: seed?.emotes ?? []
       }
     ];
@@ -283,8 +316,34 @@ export class ModSimController {
   }
 
   public rewriteForReadingChat(messages: ChatMessage[]): ChatMessage[] {
-    const reactions = ["l chatter", "ratio that chatter", "he reading us again 💀", "chat got him pressed"];
+    const reactions = [
+      "l chatter",
+      "ratio that chatter",
+      "he reading us again 💀",
+      "chat got him pressed",
+      "stop quoting us bro",
+      "read your script not ours"
+    ];
     return messages.map((message, index) => ({ ...message, text: reactions[index % reactions.length] }));
+  }
+
+  private stripBannedStarters(messages: ChatMessage[], transcript: string): ChatMessage[] {
+    const transcriptWords = transcript
+      .toLowerCase()
+      .replace(/[^a-z0-9\s']/g, " ")
+      .split(/\s+/)
+      .map((token) => token.trim())
+      .filter(Boolean);
+    if (transcriptWords.length < 2) return messages;
+    const bannedStarter = transcriptWords.slice(-2).join(" ");
+    return messages.filter((message) => {
+      const normalized = message.text
+        .toLowerCase()
+        .replace(/[^a-z0-9\s']/g, " ")
+        .replace(/\s+/g, " ")
+        .trim();
+      return !normalized.startsWith(bannedStarter);
+    });
   }
 
 

--- a/src/services/simulationOrchestrator.ts
+++ b/src/services/simulationOrchestrator.ts
@@ -260,6 +260,7 @@ export class SimulationOrchestrator {
       const captureProvider = createCaptureProvider(config);
       const provider = createInferenceProvider(config.inferenceMode);
       const startedAt = Date.now();
+      await this.visionService.awaitLatestPoll();
 
       if (!config.compliance.eulaAccepted) {
         this.emitMeta({ warning: "EULA must be accepted before simulation starts." });

--- a/src/services/visionPollingService.ts
+++ b/src/services/visionPollingService.ts
@@ -26,6 +26,7 @@ interface VisionProviderResult {
 }
 
 const DEFAULT_OPENAI_CHAT_COMPLETIONS_ENDPOINT = "https://api.openai.com/v1/chat/completions";
+const DEFAULT_VISION_MODEL = "gpt-5.4-nano-2026-03-17";
 const VISION_MODEL_FALLBACKS: Record<string, string[]> = {
   "gpt-5.4-nano-2026-03-17": ["gpt-5-mini", "gpt-4o-mini"],
   "gpt-5-nano": ["gpt-5-mini", "gpt-4o-mini"],
@@ -174,6 +175,13 @@ function visionModelCandidates(primaryModel: string): string[] {
   return candidates.filter((candidate, index) => candidate && candidates.indexOf(candidate) === index);
 }
 
+function selectVisionPrimaryModel(chatModel: string): string {
+  const normalized = chatModel.trim().toLowerCase();
+  if (normalized.includes("mini")) return DEFAULT_VISION_MODEL;
+  if (normalized.includes("nano")) return chatModel.trim();
+  return DEFAULT_VISION_MODEL;
+}
+
 function resolveOpenAiVisionEndpoint(config: SimulationConfig): string {
   const endpoint = String(config.provider.cloudEndpoint ?? "").trim();
   if (/^https:\/\/api\.openai\.com\/v1\/chat\/completions\/?$/i.test(endpoint)) return endpoint;
@@ -184,6 +192,7 @@ export class VisionPollingService {
   private timer: NodeJS.Timeout | null = null;
   private running = false;
   private readonly secretStore = new SecretStore();
+  private inFlightTick: Promise<void> | null = null;
 
   constructor(
     private readonly getConfig: () => SimulationConfig,
@@ -193,7 +202,8 @@ export class VisionPollingService {
   public start(): void {
     if (this.running) return;
     this.running = true;
-    void this.tick();
+    this.inFlightTick = this.tick();
+    void this.inFlightTick;
   }
 
   public stop(): void {
@@ -202,12 +212,24 @@ export class VisionPollingService {
       clearTimeout(this.timer);
       this.timer = null;
     }
+    this.inFlightTick = null;
+  }
+
+  public async awaitLatestPoll(maxWaitMs = 1500): Promise<void> {
+    if (!this.inFlightTick) return;
+    await Promise.race([
+      this.inFlightTick,
+      new Promise<void>((resolve) => {
+        setTimeout(resolve, maxWaitMs);
+      })
+    ]);
   }
 
   private scheduleNext(delayMs: number): void {
     if (!this.running) return;
     this.timer = setTimeout(() => {
-      void this.tick();
+      this.inFlightTick = this.tick();
+      void this.inFlightTick;
     }, delayMs);
   }
 
@@ -352,7 +374,8 @@ export class VisionPollingService {
     const endpoint = resolveOpenAiVisionEndpoint(config);
     let lastError: Error | null = null;
     let lastEmptyResult: VisionProviderResult | null = null;
-    for (const model of visionModelCandidates(config.provider.cloudModel)) {
+    const primaryVisionModel = selectVisionPrimaryModel(config.provider.cloudModel);
+    for (const model of visionModelCandidates(primaryVisionModel)) {
       const response = await fetch(endpoint, {
         method: "POST",
         headers: {
@@ -365,7 +388,7 @@ export class VisionPollingService {
             {
               role: "system",
               content:
-                "You are a stream-vision tagger. Prioritize streamer activity, facial expressions, body language, and scene energy (example outputs: focused expression, leaning in, adjusting headset, dim gaming vibe). Avoid static object lists unless they directly explain action/mood. Exclude generic dead tags such as person, man, woman, game, room, camera, monitor, stream, and video."
+                "You are a stream-vision tagger. Prioritize streamer activity, facial expressions, body language, and scene energy (example outputs: focused expression, leaning in, adjusting headset, dim gaming vibe). Use raw, unfiltered, slang-aware descriptors and describe intent, not sanitized euphemisms. If a provocative/aggressive hand gesture appears, tag it explicitly (examples: flipping off chat, middle finger, aggressive gesture). Avoid static object lists unless they directly explain action/mood. Exclude generic dead tags such as person, man, woman, game, room, camera, monitor, stream, and video."
             },
             {
               role: "user",

--- a/tests/integrationRouting.test.ts
+++ b/tests/integrationRouting.test.ts
@@ -243,7 +243,7 @@ describe("hybrid routing and failover", () => {
         if (req.headers["x-streamsim-provider"] === "groq") {
           expect(parsed.max_completion_tokens).toBeUndefined();
         } else {
-          expect(parsed.max_completion_tokens).toBeGreaterThanOrEqual(120);
+          expect(parsed.max_completion_tokens).toBeGreaterThanOrEqual(150);
         }
         expect(parsed.temperature).toBeUndefined();
         res.writeHead(200, { "Content-Type": "application/json" });
@@ -324,7 +324,7 @@ describe("hybrid routing and failover", () => {
         const parsed = JSON.parse(body);
         expect(parsed.model).toBe("gpt-5-mini");
         expect(parsed.max_tokens).toBeUndefined();
-        expect(parsed.max_completion_tokens).toBeGreaterThanOrEqual(120);
+        expect(parsed.max_completion_tokens).toBeGreaterThanOrEqual(150);
         expect(parsed.temperature).toBeUndefined();
         res.writeHead(200, { "Content-Type": "application/json" });
         res.end(JSON.stringify({ choices: [{ message: { content: '{"messages":[]}' } }] }));

--- a/tests/pipeline.test.ts
+++ b/tests/pipeline.test.ts
@@ -101,7 +101,7 @@ describe("output parser", () => {
 
 
 describe("prompt payload", () => {
-  it("requests between 2 and 8 messages based on viewer count", () => {
+  it("requests between 5 and 11 messages based on viewer count", () => {
     const low = buildPromptPayload(defaultConfig, {
       transcript: "",
       tone: { volumeRms: 0.1, paceWpm: 90 },
@@ -117,9 +117,9 @@ describe("prompt payload", () => {
       timestamp: new Date().toISOString()
     });
 
-    expect(low.requestedMessageCount).toBeGreaterThanOrEqual(2);
-    expect(low.requestedMessageCount).toBeLessThanOrEqual(8);
-    expect(high.requestedMessageCount).toBe(8);
+    expect(low.requestedMessageCount).toBeGreaterThanOrEqual(5);
+    expect(low.requestedMessageCount).toBeLessThanOrEqual(11);
+    expect(high.requestedMessageCount).toBe(11);
   });
 
   it("detects aggressive fishing only when vibe + inquiry + leading keywords align", () => {
@@ -187,8 +187,8 @@ describe("cloud generation hardening", () => {
 
     await provider.generate(payload, defaultConfig);
     const body = JSON.parse(String(fetchMock.mock.calls[0][1]?.body));
-    expect(body.max_completion_tokens).toBeGreaterThanOrEqual(120);
-    expect(body.max_completion_tokens).toBeLessThanOrEqual(240);
+    expect(body.max_completion_tokens).toBeGreaterThanOrEqual(150);
+    expect(body.max_completion_tokens).toBeLessThanOrEqual(280);
     vi.unstubAllGlobals();
   });
 


### PR DESCRIPTION
### Motivation
- Fix over-aggressive anti-echo filtering that was discarding valid AI responses and producing repetitive fallback outputs.  
- Eliminate a one-tick race where vision tags were available but not yet present on the orchestrator payload.  
- Ensure vision tagging is more literal/raw (so provocative gestures are not euphemized) and reduce JSON truncation by increasing cloud token budgeting.  
- Reduce persona mirroring by banning replies that start with the last two words of the transcript and shift to higher-quality asymmetric model routing for chat vs vision.

### Description
- Calibrated anti-echo logic in `src/services/modSimController.ts` to allow partial overlap (1–2 anchor tokens), added a 24-entry `CONTRARIAN_REGISTRY` fallback, extended reading-chat reactions, and added a `stripBannedStarters` rule to drop messages beginning with the transcript's last two words.  
- Synchronized vision and inference by tracking in-flight vision polls in `src/services/visionPollingService.ts` (`inFlightTick` + `awaitLatestPoll()`) and awaiting that poll in `src/services/simulationOrchestrator.ts` before building the prompt payload.  
- Made the vision system prompt raw/slang-aware and explicit about aggressive/provocative gestures in `src/services/visionPollingService.ts`.  
- Increased batch sizes and token budgets by changing prompt payload sizing in `src/pipeline/promptBuilder.ts` to request `5–11` messages, updating the cloud system prompt in `src/llm/realInferenceProvider.ts` to match, and raising `max_completion_tokens` bounds (new cap range ≈ `150–280`).  
- Shifted default cloud chat model to a Mini class (`gpt-5.4-mini-2026-03-17`) in `src/config/runtimeConfig.ts` and `src/public/index.html`, while vision model selection prefers appropriate nano/mini routing via a `selectVisionPrimaryModel` helper.  
- Minor prompt and persona guidance updates in `src/services/modSimController.ts` to require message brevity (`<10` words) and to explicitly ban mirroring the streamer's opening phrase.  
- Updated unit/integration expectations to reflect new batch/token bounds in `tests/pipeline.test.ts` and `tests/integrationRouting.test.ts`.

### Testing
- `npm test` (Vitest): ran the full suite and all tests passed (`112 tests passing`).  
- Attempted `npm test -- --runInBand` to mirror a slower runner but the Vitest CLI reported an unknown option error, so the plain `npm test` run was used for validation.  
- Verified affected modules with the updated unit/integration tests which were adjusted to the new `5–11` requested message range and increased token budget checks and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbf482547083268fb3178f384676a4)