### PR TITLE
Tune reaction prompting, modernize usernames, and fix chat wrapping

### DIFF
--- a/src/llm/realInferenceProvider.ts
+++ b/src/llm/realInferenceProvider.ts
@@ -172,7 +172,7 @@ function systemPromptForPayload(payload: PromptPayload): string {
   const visualQuestionDetected = /\b(look|see|show|camera|cam|color|wearing|shirt|hat|hands?|fingers?|peace sign|how many)\b/i.test(transcript);
   const staleVision = !Number.isFinite(visionAgeMs) || visionAgeMs > 12_000;
   const visionDirective = payload.context.visionTags.length
-    ? `Vision state: context.visionTags is populated (${payload.context.visionTags.map((tag) => `"${tag}"`).join(", ")}). Reference concrete tag details directly and do not invent unseen attributes.`
+    ? `Vision state: context.visionTags is populated (${payload.context.visionTags.map((tag) => `"${tag}"`).join(", ")}). Treat these tags as private grounding only; react like a participant and never narrate or list tags verbatim.`
     : "Vision state: context.visionTags is empty, so you are BLIND right now. Do not invent visuals; if asked visual questions, clearly say the cam/feed is not visible.";
   const visionFreshnessDirective = visualQuestionDetected && staleVision
     ? "Visual question detected but the latest vision sample is stale or missing. Do not guess. At least one message should ask to wait for a fresh cam update."
@@ -215,8 +215,9 @@ function systemPromptForPayload(payload: PromptPayload): string {
     "Treat context.transcript as more important than persona flavor text when they conflict.",
     "You are simulating one live viewer reacting to the streamer in real time (not a generic standalone bot).",
     "ROLE: you are a single person in chat. Use first-person phrasing and direct 'you/bro' language to the streamer. Never say 'the chat', 'chatters', or 'the audience'.",
+    "participant-only rule: react like you are in the room with the streamer right now; never narrate actions like a commentator ('smooth wave', 'you raise your hand', 'streamer does x').",
     "MIRROR BAN: never speak as if you are the streamer; react TO them, do not copy their framing.",
-    "Context grounding rule: most messages should drop 1-2 concrete keywords from transcript/tone/vision into short fragments instead of full explanations.",
+    "Context grounding rule: most messages should drop 1-2 concrete keywords from transcript/tone into short fragments instead of full explanations.",
 
     // Mushy middle: persona + behavior
     "Never mirror the streamer's exact question text back. If streamer asks 'can you hear me?', answer directly (example: 'yep we hear u').",
@@ -241,7 +242,8 @@ function systemPromptForPayload(payload: PromptPayload): string {
     "React to the stream context like a real viewer with casual slang and natural chat energy.",
     "VISION INTEGRITY: only describe visuals when context.visionTags contains descriptive words.",
     "If visionTags is empty, you are BLIND. DO NOT make 'POV' jokes or jokes about ghosts. ACT FRUSTRATED. Use phrases like: 'cam is cooked', 'L camera', 'fix the feed', 'black screen wtf', 'is my twitch lagging or is the cam dead?' If the streamer asks 'what color is my shirt' and tags are empty, you MUST say: 'we can't see you bro, fix the cam'.",
-    "If visionTags has data, reference concrete tag details directly (example: 'red hat' -> 'W hat') and do not invent unseen attributes.",
+    "If visionTags has data, convert the visual signal into a direct reaction (example: 'red hat' -> 'w hat') and do not invent unseen attributes.",
+    "Never expose internals by saying terms like 'vision tags', 'detected tags', 'capture data', or similar.",
     "Do not make excuses like lag, blur, camera angle, or feed issues unless a vision tag explicitly indicates that problem.",
     "Never mention RMS, WPM, telemetry, diagnostics, pipelines, or whether tags/transcript are missing.",
     "Do not break the fourth wall by discussing system input quality or capture internals.",

--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -136,8 +136,30 @@ button.primary { background: var(--accent-muted); border-color: #3b82f6; }
 .preview-stats { display: flex; gap: 10px; color: #bfdbfe; font-size: 0.86rem; }
 .preview-actions { margin-top: 10px; display: flex; flex-wrap: wrap; gap: 8px; }
 #chat { display: flex; flex-direction: column; gap: 8px; margin-top: 12px; }
-.chat-msg { background: var(--panel-alt); border: 1px solid #30384b; padding: 8px 10px; border-radius: 10px; line-height: 1.4; animation: pulseIn 280ms ease; }
+.chat-msg {
+  background: var(--panel-alt);
+  border: 1px solid #30384b;
+  padding: 8px 10px;
+  border-radius: 10px;
+  line-height: 1.4;
+  animation: pulseIn 280ms ease;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 4px;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
 .user { color: #7dd3fc; font-weight: 700; margin-right: 8px; }
+.chat-msg .user,
+.chat-msg .donation,
+.chat-msg .source-tag {
+  flex: 0 0 auto;
+}
+.chat-msg > span:not(.user):not(.donation):not(.source-tag) {
+  min-width: 0;
+  white-space: normal;
+}
 .donation { color: #facc15; margin-left: 8px; }
 .source-tag {
   margin-left: 8px;

--- a/src/services/identityManager.ts
+++ b/src/services/identityManager.ts
@@ -2,29 +2,29 @@ import { ChatMessage } from "../core/types.js";
 import { loadBanlist } from "../security/banlistRegistry.js";
 
 const ADJECTIVES = [
-  "Salty", "Sleepy", "Turbo", "Pixel", "Glitch", "Cyber", "Stealth", "Macro", "Laggy", "Sweaty", "Cracked", "Hardcore", "Legendary",
-  "Hype", "Sus", "Pog", "Cursed", "Random", "Spicy", "Yeet", "Maximum", "Absolute", "Chill", "Golden", "Radiant", "Gloom", "Mellow",
-  "Cozy", "Lunar", "Velvet", "Honest", "Quiet", "Sneaky", "Savage", "Primal", "Ancient", "Hyper", "Neon", "Frozen", "Electric", "Shadow",
-  "Iron", "Toxic", "Mega", "Ultra", "Infinite", "Bitter", "Fluffy", "Grumpy", "Wild", "Calm", "Brave", "Fancy", "Clumsy", "Dorky",
-  "Funky", "Jolly", "Lucky", "Misty", "Nerdy", "Odd", "Proud", "Shady", "Silly", "Tame", "Vast", "Witty", "Young", "Zesty", "Astral",
-  "Blazing", "Cobalt", "Dusty", "Eerie", "Fierce", "Gilded", "Hollow", "Icy", "Jaded", "Keen", "Lucid", "Mystic", "Noble", "Opal",
-  "Pale", "Quartz", "Rustic", "Solar", "Tidal", "Urban", "Vivid", "Worn", "Xenon", "Amber", "Bold", "Crisp", "Dire", "Elite", "Faded", "Grand"
+  "salty", "sleepy", "turbo", "pixel", "glitch", "cyber", "stealth", "macro", "laggy", "sweaty", "cracked", "hardcore", "legendary",
+  "hype", "sus", "pog", "cursed", "random", "spicy", "yeet", "maximum", "absolute", "chill", "golden", "radiant", "gloom", "mellow",
+  "cozy", "lunar", "velvet", "honest", "quiet", "sneaky", "savage", "primal", "ancient", "hyper", "neon", "frozen", "electric", "shadow",
+  "iron", "toxic", "mega", "ultra", "infinite", "bitter", "fluffy", "grumpy", "wild", "calm", "brave", "fancy", "clumsy", "dorky",
+  "funky", "jolly", "lucky", "misty", "nerdy", "odd", "proud", "shady", "silly", "tame", "vast", "witty", "young", "zesty", "astral",
+  "blazing", "cobalt", "dusty", "eerie", "fierce", "gilded", "hollow", "icy", "jaded", "keen", "lucid", "mystic", "noble", "opal",
+  "pale", "quartz", "rustic", "solar", "tidal", "urban", "vivid", "worn", "xenon", "amber", "bold", "crisp", "dire", "elite", "faded", "grand"
 ] as const;
 
 const NOUNS = [
-  "Bot", "Frame", "Ping", "Keybind", "Console", "Controller", "Sprite", "Buff", "Nerf", "Carry", "Clutch", "Goblin", "Gremlin", "Meme",
-  "Troll", "Noob", "Whale", "Simp", "Main", "Alt", "Panda", "Sloth", "Wizard", "Tea", "Rain", "Vibe", "Cloud", "Moon", "Fern", "Slime",
-  "Ghost", "Rex", "Raptor", "Falcon", "Kraken", "Fox", "Badger", "Viper", "Knight", "Rogue", "Titan", "Wolf", "Scrub", "Pilot", "Captain",
-  "Legend", "Myth", "Hero", "Villain", "Scout", "Guard", "Beast", "Bird", "Cat", "Dog", "Dragon", "Fish", "Horse", "Lion", "Mouse",
-  "Shark", "Snake", "Tiger", "Zebra", "Bloom", "Blaze", "Bolt", "Core", "Dust", "Edge", "Flame", "Gear", "Heart", "Ink", "Jet", "Kite",
-  "Leaf", "Mist", "Night", "Orb", "Pulse", "Quill", "Reef", "Star", "Thorn", "Unit", "Void", "Wave", "Yard", "Zone", "Atom", "Beam",
-  "Chip", "Disk", "Echo", "Flux", "Grid", "Halo", "Icon", "Jolt"
+  "bot", "frame", "ping", "keybind", "console", "controller", "sprite", "buff", "nerf", "carry", "clutch", "goblin", "gremlin", "meme",
+  "troll", "noob", "whale", "simp", "main", "alt", "panda", "sloth", "wizard", "tea", "rain", "vibe", "cloud", "moon", "fern", "slime",
+  "ghost", "rex", "raptor", "falcon", "kraken", "fox", "badger", "viper", "knight", "rogue", "titan", "wolf", "scrub", "pilot", "captain",
+  "legend", "myth", "hero", "villain", "scout", "guard", "beast", "bird", "cat", "dog", "dragon", "fish", "horse", "lion", "mouse",
+  "shark", "snake", "tiger", "zebra", "bloom", "blaze", "bolt", "core", "dust", "edge", "flame", "gear", "heart", "ink", "jet", "kite",
+  "leaf", "mist", "night", "orb", "pulse", "quill", "reef", "star", "thorn", "unit", "void", "wave", "yard", "zone", "atom", "beam",
+  "chip", "disk", "echo", "flux", "grid", "halo", "icon", "jolt"
 ] as const;
 
 const RARE_SINGLES = [
-  "Vesper", "Zenith", "Kael", "Echo", "Jinx", "Riot", "Flux", "Cipher", "Ghost", "Onyx", "Rogue", "Sola", "Nova", "Raven", "Ash", "Blade",
-  "Neon", "Frost", "Grimm", "Rune", "Lynx", "Nyx", "Pax", "Quill", "Rhys", "Sage", "Trix", "Vale", "Wren", "Xane", "Yuri", "Zane", "Aero",
-  "Bane", "Crux", "Dash", "Ezra", "Finn", "Glee", "Hawk", "Ion", "Jax", "Kite", "Lux", "Miro", "Nero", "Odin", "Pike", "Quinn", "Reed"
+  "vesper", "zenith", "kael", "echo", "jinx", "riot", "flux", "cipher", "ghost", "onyx", "rogue", "sola", "nova", "raven", "ash", "blade",
+  "neon", "frost", "grimm", "rune", "lynx", "nyx", "pax", "quill", "rhys", "sage", "trix", "vale", "wren", "xane", "yuri", "zane", "aero",
+  "bane", "crux", "dash", "ezra", "finn", "glee", "hawk", "ion", "jax", "kite", "lux", "miro", "nero", "odin", "pike", "quinn", "reed"
 ] as const;
 
 const USERNAME_BLACKLIST = ["angrybannedword", "offensive", "slur"] as const;
@@ -93,29 +93,27 @@ export class IdentityManager {
   private createNewIdentity(): string {
     const tierRoll = Math.random() * 100;
 
-    // Tier 3: OG handles (5%)
-    if (tierRoll <= 5) {
-      return pick(RARE_SINGLES);
+    // Tier 3: modern single-word handles (35%)
+    if (tierRoll <= 35) {
+      const single = pick(RARE_SINGLES);
+      return this.randomChance(35) ? `${single}${Math.floor(Math.random() * 90) + 10}` : single;
     }
 
     const adj = pick(ADJECTIVES);
     const noun = pick(NOUNS);
 
-    // Tier 2: Established (25%)
-    if (tierRoll <= 30) {
+    // Tier 2: clean lowercase compounds (40%)
+    if (tierRoll <= 75) {
       return `${adj}${noun}`;
     }
 
-    // Tier 1: Common (70%)
+    // Tier 1: legacy separator/suffix handles (25%)
     const separatorRoll = Math.random() * 100;
     let separator = "";
     if (separatorRoll > 40 && separatorRoll <= 80) separator = "_";
     else if (separatorRoll > 80) separator = ".";
 
-    let base = `${adj}${separator}${noun}`;
-    if (this.randomChance(50)) {
-      base = base.toLowerCase();
-    }
+    const base = `${adj}${separator}${noun}`;
 
     let suffix = this.generateNumberSuffix();
     if (separator !== "_" && this.randomChance(30)) {

--- a/src/services/modSimController.ts
+++ b/src/services/modSimController.ts
@@ -86,7 +86,7 @@ export class ModSimController {
       transcript
         ? `Highest priority: react to latest streamer words: "${transcriptTail}".`
         : "Streamer is currently quiet; continue ongoing topic naturally.",
-      `Vision tags: ${payload.context.visionTags.length ? payload.context.visionTags.join(", ") : "none"}.`,
+      `Visual grounding (internal only): ${payload.context.visionTags.length ? payload.context.visionTags.join(", ") : "none"}. React like a participant and never narrate these tags verbatim.`,
       `Vibe=${payload.context.vibe ?? "unknown"}; Intent=${payload.context.intent ?? "none"}; Command=${Boolean(payload.context.isCommand)}.`,
       `Behavioral modes: ${payload.behavioralModes.join(", ")}.`,
       `Fishing state: ${fishingState}.`,
@@ -96,6 +96,7 @@ export class ModSimController {
       "DO NOT mirror the streamer's opening phrase; never start with the transcript's last 2 words.",
       bannedTermDirective,
       "Never say: 'the viewer says', 'I am an AI', or explain system internals.",
+      "Participant-only voice: react to the streamer in first person, never as a play-by-play commentator.",
       "Keep messages short and non-repetitive."
     ].join(" ");
   }
@@ -255,10 +256,9 @@ export class ModSimController {
       }
     });
 
-    const maxWords = 4;
+    const maxWords = 6;
     const minimumShortRatio = 0.8;
     const countWords = (text: string) => text.trim().split(/\s+/).filter(Boolean).length;
-    const shorten = (text: string) => text.trim().split(/\s+/).slice(0, maxWords).join(" ");
     const requiredShort = Math.ceil(deduped.length * minimumShortRatio);
     let shortCount = deduped.filter((message) => countWords(message.text) <= maxWords).length;
     if (shortCount < requiredShort) {
@@ -268,7 +268,7 @@ export class ModSimController {
         .sort((a, b) => b.words - a.words);
       for (const entry of longIndices) {
         if (shortCount >= requiredShort) break;
-        deduped[entry.index].text = shorten(deduped[entry.index].text);
+        deduped[entry.index].text = this.enforceWordCapSmart(deduped[entry.index].text, maxWords);
         shortCount += 1;
       }
     }


### PR DESCRIPTION
### Motivation
- Prevent the model from narrating streamer actions or vision internals and force first-person participant reactions so generated chat feels like a real viewer instead of a commentator.
- Stop UI chat messages from visually truncating in the overlay by improving CSS wrapping behavior.
- Refresh generated usernames to feel more modern and less legacy-formatted.
- Reduce overly aggressive message truncation so short-message constraints preserve meaning.

### Description
- Tightened system prompting in `systemPromptForPayload` (src/llm/realInferenceProvider.ts) to treat vision tags as private grounding, add a "participant-only" rule, and steer the model away from play-by-play narration. 
- Mirrored the participant-only framing in the ModSim fallback prompt (src/services/modSimController.ts) and changed the visual grounding line to mark vision details as internal-only.
- Relaxed short-message enforcement in `ModSimController` by raising the short-target to `6` words and switching truncation to use the existing `enforceWordCapSmart` compression instead of a blind slice. 
- Modernized `IdentityManager` (src/services/identityManager.ts) to favor lowercase single-word and clean compound handles by lowercasing source lists, increasing the chance of single-word `RARE_SINGLES`, and rebalancing tier probabilities while keeping legacy formats available.
- Fixed chat bubble wrapping in the overlay stylesheet (src/public/styles.css) by making `.chat-msg` a flex container with `flex-wrap`, `overflow-wrap: anywhere`, `word-break: break-word`, and ensuring user/donation/source spans don't force truncation.

### Testing
- Ran unit/integration tests with `npm test -- tests/identityManager.test.ts tests/modSimController.test.ts tests/integrationRouting.test.ts` and all specified test files passed. 
- Test summary: 3 test files, 21 tests total, all passed (`✓ tests/identityManager.test.ts`, `✓ tests/modSimController.test.ts`, `✓ tests/integrationRouting.test.ts`).
- No new dependencies were added and no API contracts were changed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc16be0c3c8326a3fdbad391e1161f)