### PR TITLE
Reduce empty vision logging and add legacy-style identity generation

### DIFF
--- a/src/capture/deviceCapturePipeline.ts
+++ b/src/capture/deviceCapturePipeline.ts
@@ -45,8 +45,10 @@ export class DeviceCapturePipeline {
       return;
     }
     this.lastVisionSample = { tags, capturedAt: Date.now() };
-    // eslint-disable-next-line no-console
-    console.log("[DeviceCapturePipeline] Saved latest vision tags", { tags, capturedAt: this.lastVisionSample.capturedAt });
+    if (tags.length > 0) {
+      // eslint-disable-next-line no-console
+      console.log("[DeviceCapturePipeline] Saved latest vision tags", { tags, capturedAt: this.lastVisionSample.capturedAt });
+    }
   }
 
   public ingestIntelligenceSample(sample: Pick<StreamContext, "vibe" | "topic" | "intent" | "isCommand" | "intentScore">): void {

--- a/src/services/identityManager.ts
+++ b/src/services/identityManager.ts
@@ -85,6 +85,41 @@ export class IdentityManager {
     return `${Math.floor(Math.random() * 99) + 1}`;
   }
 
+  private legacyTokenCase(token: string): string {
+    const styleRoll = Math.random() * 100;
+    if (styleRoll <= 30) return token;
+    if (styleRoll <= 55) return token.charAt(0).toUpperCase() + token.slice(1);
+    if (styleRoll <= 72) return token.toUpperCase();
+    if (styleRoll <= 88) return token.charAt(0).toUpperCase() + token.slice(1).toLowerCase();
+
+    const letters = token.split("");
+    for (let i = 0; i < letters.length; i += 1) {
+      if (/[a-z]/i.test(letters[i]) && this.randomChance(45)) {
+        letters[i] = this.randomChance(50) ? letters[i].toUpperCase() : letters[i].toLowerCase();
+      }
+    }
+    return letters.join("");
+  }
+
+  private generateLegacyIdentity(adj: string, noun: string): string {
+    const separatorRoll = Math.random() * 100;
+    let separator = "";
+    if (separatorRoll > 35 && separatorRoll <= 65) separator = "_";
+    else if (separatorRoll > 65 && separatorRoll <= 80) separator = ".";
+
+    let core = `${this.legacyTokenCase(adj)}${separator}${this.legacyTokenCase(noun)}`;
+    if (this.randomChance(25)) core = `${core}${this.randomChance(50) ? "X" : "x"}`;
+
+    const numberSuffixRoll = Math.random() * 100;
+    if (numberSuffixRoll <= 35) core = `${core}${this.generateNumberSuffix()}`;
+    else if (numberSuffixRoll <= 55) core = `${core}${Math.floor(Math.random() * 900) + 100}`;
+
+    if (this.randomChance(20)) core = `${this.randomChance(50) ? "xX" : "Xx"}${core}`;
+    if (this.randomChance(15)) core = `${core}${this.randomChance(50) ? "Xx" : "xX"}`;
+
+    return core;
+  }
+
   private passesSafetyFilter(username: string): boolean {
     const normalized = username.toLowerCase();
     return !this.banTerms.some((term) => normalized.includes(term));
@@ -93,16 +128,21 @@ export class IdentityManager {
   private createNewIdentity(): string {
     const tierRoll = Math.random() * 100;
 
+    const adj = pick(ADJECTIVES);
+    const noun = pick(NOUNS);
+
+    // Legacy throwback names with caps + numbers (~4%)
+    if (tierRoll <= 4) {
+      return this.generateLegacyIdentity(adj, noun);
+    }
+
     // Tier 3: modern single-word handles (35%)
-    if (tierRoll <= 35) {
+    if (tierRoll <= 40) {
       const single = pick(RARE_SINGLES);
       return this.randomChance(35) ? `${single}${Math.floor(Math.random() * 90) + 10}` : single;
     }
 
-    const adj = pick(ADJECTIVES);
-    const noun = pick(NOUNS);
-
-    // Tier 2: clean lowercase compounds (40%)
+    // Tier 2: mostly clean compounds (35%)
     if (tierRoll <= 75) {
       return `${adj}${noun}`;
     }


### PR DESCRIPTION
### Motivation

- Avoid noisy console output when vision samples contain no tags by only logging when meaningful tags are saved.
- Broaden the variety of generated spectator identities with legacy/throwback handle styles (caps, separators, numeric suffixes) to more closely mimic historical username patterns.

### Description

- In `src/capture/deviceCapturePipeline.ts` change `ingestVisionSample` to only `console.log` the saved vision tags when `tags.length > 0` to suppress logs for placeholder/empty payloads.
- In `src/services/identityManager.ts` add `legacyTokenCase` and `generateLegacyIdentity` helpers that produce mixed-case tokens, optional separators (`_`, `.`), random `x/X` decorations, and varied numeric suffixes to emulate legacy handles.
- Update `createNewIdentity` to preselect `adj` and `noun`, insert a small (~4%) legacy-style identity branch, and adjust tier probability thresholds for single-word, compound, and legacy-separator name formats.
- Preserve the existing safety filter `passesSafetyFilter` and reuse `generateNumberSuffix`; overall randomness and suffix rules have been extended but existing flows remain intact.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc1a6a01bc8326917f0cc507269a11)