### PR TITLE
Add legacy-style identity generation, truncate vision payload logs, and avoid logging empty vision tags

### DIFF
--- a/src/capture/deviceCapturePipeline.ts
+++ b/src/capture/deviceCapturePipeline.ts
@@ -45,8 +45,10 @@ export class DeviceCapturePipeline {
       return;
     }
     this.lastVisionSample = { tags, capturedAt: Date.now() };
-    // eslint-disable-next-line no-console
-    console.log("[DeviceCapturePipeline] Saved latest vision tags", { tags, capturedAt: this.lastVisionSample.capturedAt });
+    if (tags.length > 0) {
+      // eslint-disable-next-line no-console
+      console.log("[DeviceCapturePipeline] Saved latest vision tags", { tags, capturedAt: this.lastVisionSample.capturedAt });
+    }
   }
 
   public ingestIntelligenceSample(sample: Pick<StreamContext, "vibe" | "topic" | "intent" | "isCommand" | "intentScore">): void {

--- a/src/services/identityManager.ts
+++ b/src/services/identityManager.ts
@@ -85,6 +85,41 @@ export class IdentityManager {
     return `${Math.floor(Math.random() * 99) + 1}`;
   }
 
+  private legacyTokenCase(token: string): string {
+    const styleRoll = Math.random() * 100;
+    if (styleRoll <= 30) return token;
+    if (styleRoll <= 55) return token.charAt(0).toUpperCase() + token.slice(1);
+    if (styleRoll <= 72) return token.toUpperCase();
+    if (styleRoll <= 88) return token.charAt(0).toUpperCase() + token.slice(1).toLowerCase();
+
+    const letters = token.split("");
+    for (let i = 0; i < letters.length; i += 1) {
+      if (/[a-z]/i.test(letters[i]) && this.randomChance(45)) {
+        letters[i] = this.randomChance(50) ? letters[i].toUpperCase() : letters[i].toLowerCase();
+      }
+    }
+    return letters.join("");
+  }
+
+  private generateLegacyIdentity(adj: string, noun: string): string {
+    const separatorRoll = Math.random() * 100;
+    let separator = "";
+    if (separatorRoll > 35 && separatorRoll <= 65) separator = "_";
+    else if (separatorRoll > 65 && separatorRoll <= 80) separator = ".";
+
+    let core = `${this.legacyTokenCase(adj)}${separator}${this.legacyTokenCase(noun)}`;
+    if (this.randomChance(25)) core = `${core}${this.randomChance(50) ? "X" : "x"}`;
+
+    const numberSuffixRoll = Math.random() * 100;
+    if (numberSuffixRoll <= 35) core = `${core}${this.generateNumberSuffix()}`;
+    else if (numberSuffixRoll <= 55) core = `${core}${Math.floor(Math.random() * 900) + 100}`;
+
+    if (this.randomChance(20)) core = `${this.randomChance(50) ? "xX" : "Xx"}${core}`;
+    if (this.randomChance(15)) core = `${core}${this.randomChance(50) ? "Xx" : "xX"}`;
+
+    return core;
+  }
+
   private passesSafetyFilter(username: string): boolean {
     const normalized = username.toLowerCase();
     return !this.banTerms.some((term) => normalized.includes(term));
@@ -93,16 +128,21 @@ export class IdentityManager {
   private createNewIdentity(): string {
     const tierRoll = Math.random() * 100;
 
+    const adj = pick(ADJECTIVES);
+    const noun = pick(NOUNS);
+
+    // Legacy throwback names with caps + numbers (~4%)
+    if (tierRoll <= 4) {
+      return this.generateLegacyIdentity(adj, noun);
+    }
+
     // Tier 3: modern single-word handles (35%)
-    if (tierRoll <= 35) {
+    if (tierRoll <= 40) {
       const single = pick(RARE_SINGLES);
       return this.randomChance(35) ? `${single}${Math.floor(Math.random() * 90) + 10}` : single;
     }
 
-    const adj = pick(ADJECTIVES);
-    const noun = pick(NOUNS);
-
-    // Tier 2: clean lowercase compounds (40%)
+    // Tier 2: mostly clean compounds (35%)
     if (tierRoll <= 75) {
       return `${adj}${noun}`;
     }

--- a/src/services/visionPollingService.ts
+++ b/src/services/visionPollingService.ts
@@ -25,6 +25,19 @@ interface VisionProviderResult {
   model?: string;
 }
 
+function truncateForLog(value: string, maxLen = 96): string {
+  if (value.length <= maxLen) return value;
+  return `${value.slice(0, maxLen)}... (${value.length - maxLen} more chars)`;
+}
+
+function summarizeEndpointPayloadForLog(payload: VisionEndpointPayload): VisionEndpointPayload {
+  return {
+    ...payload,
+    dataUrl: typeof payload.dataUrl === "string" ? truncateForLog(payload.dataUrl) : payload.dataUrl,
+    imageBase64: typeof payload.imageBase64 === "string" ? truncateForLog(payload.imageBase64) : payload.imageBase64
+  };
+}
+
 const DEFAULT_OPENAI_CHAT_COMPLETIONS_ENDPOINT = "https://api.openai.com/v1/chat/completions";
 const DEFAULT_VISION_MODEL = "gpt-5.4-nano-2026-03-17";
 const VISION_MODEL_FALLBACKS: Record<string, string[]> = {
@@ -295,7 +308,7 @@ export class VisionPollingService {
         }
       }
       // eslint-disable-next-line no-console
-      console.log("[VisionPollingService] vision endpoint payload", endpointPayload);
+      console.log("[VisionPollingService] vision endpoint payload", summarizeEndpointPayloadForLog(endpointPayload));
 
       const providerResult: VisionProviderResult =
         config.capture.visionProvider === "openai"


### PR DESCRIPTION
### Motivation
- Prevent extremely large or sensitive payloads (like base64 images) from overflowing logs and improve log readability.
- Diversify generated viewer identities by adding legacy-style handles with mixed casing, separators, and numeric suffixes.
- Stop emitting a saved-vision log when an incoming vision sample contains no tags to reduce noise.

### Description
- In `visionPollingService.ts` added `truncateForLog` and `summarizeEndpointPayloadForLog` and use the summary when logging `endpointPayload` so `dataUrl` and `imageBase64` are truncated for logs.
- In `deviceCapturePipeline.ts` guard the saved-vision console log so it only runs when `tags.length > 0` to avoid logging placeholder/empty samples.
- In `identityManager.ts` added `legacyTokenCase` and `generateLegacyIdentity` helpers, changed `createNewIdentity` to sometimes return legacy throwback names and adjusted tier probability thresholds and naming logic.

### Testing
- Ran unit tests with `npm test` and they passed.
- Ran linting with `npm run lint` and no lint errors were reported.
- Verified TypeScript types with `tsc --noEmit` and the typecheck completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc1a6a01bc8326917f0cc507269a11)