### PR TITLE
Configurable live-monitor vision sampling and live-frame versioning for polling fallback

### DIFF
--- a/src/capture/visionFrameStore.ts
+++ b/src/capture/visionFrameStore.ts
@@ -1,15 +1,17 @@
 interface StoredVisionFrame {
   dataUrl: string;
   updatedAt: number;
+  version: number;
 }
 
 class VisionFrameStore {
   private latestFrame: StoredVisionFrame | null = null;
+  private nextVersion = 1;
 
   public setFrame(dataUrl: string): void {
     const trimmed = dataUrl.trim();
     if (!trimmed) return;
-    this.latestFrame = { dataUrl: trimmed, updatedAt: Date.now() };
+    this.latestFrame = { dataUrl: trimmed, updatedAt: Date.now(), version: this.nextVersion++ };
   }
 
   public getLatestFrame(): StoredVisionFrame | null {
@@ -18,6 +20,7 @@ class VisionFrameStore {
 
   public reset(): void {
     this.latestFrame = null;
+    this.nextVersion = 1;
   }
 }
 

--- a/src/config/runtimeConfig.ts
+++ b/src/config/runtimeConfig.ts
@@ -15,7 +15,7 @@ export const defaultConfig: SimulationConfig = {
   inferenceMode: "openai",
   capture: {
     visionEnabled: true,
-    visionIntervalSec: 25,
+    visionIntervalSec: 7,
     visionProvider: "local",
     useRealCapture: true,
     sttEndpoint:

--- a/src/public/app.js
+++ b/src/public/app.js
@@ -68,7 +68,7 @@ const MIC_CHECK_PROBE_SECONDS = 3.5;
 const MIC_CHECK_BUFFER_SECONDS = 8;
 const MIC_CHECK_MIN_SAMPLES = 12000;
 const CAMERA_FRAME_CONFIRM_TIMEOUT_MS = 3000;
-const LIVE_MONITOR_VISION_SAMPLE_MS = 8000;
+const DEFAULT_LIVE_MONITOR_VISION_SAMPLE_MS = 7000;
 const STATUS_AUTO_REFRESH_MS = 5000;
 const STT_DEFAULT_ENDPOINTS = {
   "local-whisper": "http://127.0.0.1:7778/stt",
@@ -452,6 +452,24 @@ async function pushLiveVisionSample() {
   await post("/api/capture/vision-sample", { dataUrl });
 }
 
+function getLiveMonitorVisionSampleMs() {
+  const configuredIntervalSec = Number(controls.visionIntervalSec?.value);
+  const safeIntervalSec = Number.isFinite(configuredIntervalSec)
+    ? Math.max(5, Math.min(120, Math.floor(configuredIntervalSec)))
+    : Math.round(DEFAULT_LIVE_MONITOR_VISION_SAMPLE_MS / 1000);
+  return safeIntervalSec * 1000;
+}
+
+function restartLiveMonitorVisionSampling() {
+  if (!liveMonitorStream) return;
+  if (liveMonitorVisionInterval) clearInterval(liveMonitorVisionInterval);
+  const sampleMs = getLiveMonitorVisionSampleMs();
+  liveMonitorVisionInterval = setInterval(() => {
+    void pushLiveVisionSample();
+  }, sampleMs);
+  setLiveMonitorStatus(`Camera and microphone active for live monitor (vision snapshots every ${Math.round(sampleMs / 1000)}s).`, "ok");
+}
+
 async function startLiveMonitor() {
   if (!navigator.mediaDevices?.getUserMedia) {
     throw new Error("Browser does not support getUserMedia for live monitor.");
@@ -489,12 +507,8 @@ async function startLiveMonitor() {
     const rms = Math.sqrt(sum / samples.length);
     drawVoiceMeter(Math.min(1, rms * 3.2));
   }, 90);
-  liveMonitorVisionInterval = setInterval(() => {
-    void pushLiveVisionSample();
-  }, LIVE_MONITOR_VISION_SAMPLE_MS);
+  restartLiveMonitorVisionSampling();
   void pushLiveVisionSample();
-
-  setLiveMonitorStatus("Camera and microphone active for live monitor (vision snapshots every 8s).", "ok");
   return true;
 }
 
@@ -1390,6 +1404,10 @@ liveMonitorEnabled?.addEventListener("change", async () => {
     liveMonitorEnabled.checked = false;
     stopLiveMonitor();
   }
+});
+
+controls.visionIntervalSec?.addEventListener("change", () => {
+  restartLiveMonitorVisionSampling();
 });
 
 window.addEventListener("beforeunload", () => {

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -120,7 +120,7 @@
                   <option value="openai">Cloud (OpenAI)</option>
                 </select>
               </label>
-              <label>Vision Interval (seconds) <input id="visionIntervalSec" type="number" min="5" max="120" value="25" /></label>
+              <label>Vision Interval (seconds) <input id="visionIntervalSec" type="number" min="5" max="120" value="7" /></label>
               <label>STT Provider
                 <select id="sttProvider">
                   <option value="local-whisper">Local Whisper (localhost)</option>

--- a/src/services/visionPollingService.ts
+++ b/src/services/visionPollingService.ts
@@ -206,6 +206,7 @@ export class VisionPollingService {
   private running = false;
   private readonly secretStore = new SecretStore();
   private inFlightTick: Promise<void> | null = null;
+  private lastConsumedLiveFrameVersion = 0;
 
   constructor(
     private readonly getConfig: () => SimulationConfig,
@@ -226,6 +227,7 @@ export class VisionPollingService {
       this.timer = null;
     }
     this.inFlightTick = null;
+    this.lastConsumedLiveFrameVersion = 0;
   }
 
   public async awaitLatestPoll(maxWaitMs = 1500): Promise<void> {
@@ -266,7 +268,7 @@ export class VisionPollingService {
           endpointPayload = ((await endpointResponse.json()) ?? {}) as VisionEndpointPayload;
         } catch (endpointError) {
           if (config.capture.visionProvider !== "openai") throw endpointError;
-          const latestFrame = sharedVisionFrameStore.getLatestFrame();
+          const latestFrame = await this.awaitNextLiveFrame(delayMs);
           if (!latestFrame) throw endpointError;
           endpointPayload = { dataUrl: latestFrame.dataUrl };
           this.emitMeta({
@@ -276,7 +278,7 @@ export class VisionPollingService {
           });
         }
       } else if (config.capture.visionProvider === "openai") {
-        const latestFrame = sharedVisionFrameStore.getLatestFrame();
+        const latestFrame = await this.awaitNextLiveFrame(delayMs);
         if (!latestFrame) {
           this.emitMeta({
             warnings: ["Vision polling skipped: waiting for browser camera frame upload."],
@@ -297,7 +299,7 @@ export class VisionPollingService {
         return;
       }
       if (config.capture.visionProvider === "openai" && !payloadHasVisionSignal(endpointPayload)) {
-        const latestFrame = sharedVisionFrameStore.getLatestFrame();
+        const latestFrame = await this.awaitNextLiveFrame(delayMs);
         if (latestFrame) {
           endpointPayload = { ...endpointPayload, dataUrl: latestFrame.dataUrl };
           this.emitMeta({
@@ -365,6 +367,31 @@ export class VisionPollingService {
     }
 
     this.scheduleNext(delayMs);
+  }
+
+  private async awaitNextLiveFrame(delayMs: number): Promise<{ dataUrl: string; updatedAt: number; version: number } | null> {
+    const freshest = sharedVisionFrameStore.getLatestFrame();
+    if (freshest && freshest.version > this.lastConsumedLiveFrameVersion) {
+      this.lastConsumedLiveFrameVersion = freshest.version;
+      return freshest;
+    }
+
+    const waitBudgetMs = Math.max(250, Math.min(2000, Math.floor(delayMs * 0.35)));
+    const waitUntil = Date.now() + waitBudgetMs;
+
+    while (Date.now() < waitUntil) {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      const candidate = sharedVisionFrameStore.getLatestFrame();
+      if (candidate && candidate.version > this.lastConsumedLiveFrameVersion) {
+        this.lastConsumedLiveFrameVersion = candidate.version;
+        return candidate;
+      }
+    }
+
+    const fallback = sharedVisionFrameStore.getLatestFrame();
+    if (!fallback) return null;
+    this.lastConsumedLiveFrameVersion = fallback.version;
+    return fallback;
   }
 
   private async fetchOpenAiVisionTags(config: SimulationConfig, payload: VisionEndpointPayload): Promise<VisionProviderResult> {

--- a/tests/uiRuntimeVerification.test.ts
+++ b/tests/uiRuntimeVerification.test.ts
@@ -39,8 +39,9 @@ describe("runtime verification + monitoring UI wiring", () => {
     expect(appJs).toContain("msg.username ? `${msg.username}:` : \"\"");
     expect(appJs).toContain("function pushLiveVisionSample()");
     expect(appJs).toContain("await post(\"/api/capture/vision-sample\", { dataUrl })");
-    expect(appJs).toContain("LIVE_MONITOR_VISION_SAMPLE_MS = 8000");
-    expect(appJs).toContain("vision snapshots every 8s");
+    expect(appJs).toContain("DEFAULT_LIVE_MONITOR_VISION_SAMPLE_MS = 7000");
+    expect(appJs).toContain("function restartLiveMonitorVisionSampling()");
+    expect(appJs).toContain("vision snapshots every ${Math.round(sampleMs / 1000)}s");
   });
 
   it("keeps runtime verification and live monitor markup IDs in index.html", () => {


### PR DESCRIPTION
### Motivation

- Reduce the default live monitor snapshot interval and allow operators to configure it from the UI to improve responsiveness. 
- Ensure the server-side vision polling reliably consumes fresh browser-uploaded frames instead of repeatedly reusing the same frame.

### Description

- Added a `version` field to `StoredVisionFrame` and a `nextVersion` counter to `VisionFrameStore`, and reset the counter in `reset()` to track freshness of browser frames. 
- Made the default vision sampling interval 7s in `defaultConfig` and `src/public/index.html` by changing `visionIntervalSec` default from `25` to `7`. 
- Updated client-side live monitor logic in `src/public/app.js` to use `DEFAULT_LIVE_MONITOR_VISION_SAMPLE_MS = 7000`, added `getLiveMonitorVisionSampleMs()` to safely read `visionIntervalSec` from controls, and added `restartLiveMonitorVisionSampling()` plus a change listener to restart sampling when the interval changes. 
- Enhanced `VisionPollingService` to track `lastConsumedLiveFrameVersion` and added `awaitNextLiveFrame()` to wait briefly for a newer live frame (or fall back to the latest) before using browser frames as a fallback when external endpoints return no image or are unavailable.

### Testing

- Updated and ran the UI runtime verification unit test `tests/uiRuntimeVerification.test.ts`, which asserts the new client functions and changed constants, and the test completed successfully. 
- Ran the test suite that covers runtime verification and live monitor wiring and it passed with the updated expectations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc2b0090b48326b787e626ffda2912)