### PR TITLE
Wrap ModSim dynamic context with canonical master rule-stack

### DIFF
--- a/src/llm/realInferenceProvider.ts
+++ b/src/llm/realInferenceProvider.ts
@@ -155,7 +155,7 @@ function extractProviderTextOrThrow(data: ProviderResponseShape, providerLabel: 
   throw new Error(`Provider returned empty content (${providerLabel})`);
 }
 
-function systemPromptForPayload(payload: PromptPayload): string {
+export function systemPromptForPayload(payload: PromptPayload): string {
   const transcript = payload.context.transcript.trim();
   const rawTranscriptTail = transcript.slice(-230);
   const transcriptTail = rawTranscriptTail.includes(" ")

--- a/src/services/modSimController.ts
+++ b/src/services/modSimController.ts
@@ -79,25 +79,19 @@ export class ModSimController {
       : "No banned slang this tick.";
 
     return [
-      `Return strict JSON only: {"messages":[{"text":"string","emotes":["string"],"donationCents":number|null,"ttsText":string|null}]}.`,
-      `messages must contain exactly ${payload.requestedMessageCount} entries.`,
-      "Each message text MUST be under 10 words. Quality over quantity.",
+      "Daily briefing (dynamic context follows; global handbook rules are appended after this block).",
       `Topic lock: ${streamTopic}.`,
       transcript
-        ? `Highest priority: react to latest streamer words: "${transcriptTail}".`
+        ? `Latest streamer tail: "${transcriptTail}".`
         : "Streamer is currently quiet; continue ongoing topic naturally.",
-      `Visual grounding (internal only): ${payload.context.visionTags.length ? payload.context.visionTags.join(", ") : "none"}. React like a participant and never narrate these tags verbatim.`,
+      `Visual grounding (internal only): ${payload.context.visionTags.length ? payload.context.visionTags.join(", ") : "none"}.`,
       `Vibe=${payload.context.vibe ?? "unknown"}; Intent=${payload.context.intent ?? "none"}; Command=${Boolean(payload.context.isCommand)}.`,
       `Behavioral modes: ${payload.behavioralModes.join(", ")}.`,
       `Fishing state: ${fishingState}.`,
       primacyDirective,
       chaosDirective,
       degeneracyDirective,
-      "DO NOT mirror the streamer's opening phrase; never start with the transcript's last 2 words.",
-      bannedTermDirective,
-      "Never say: 'the viewer says', 'I am an AI', or explain system internals.",
-      "Participant-only voice: react to the streamer in first person, never as a play-by-play commentator.",
-      "Keep messages short and non-repetitive."
+      bannedTermDirective
     ].join(" ");
   }
 

--- a/src/services/simulationOrchestrator.ts
+++ b/src/services/simulationOrchestrator.ts
@@ -14,6 +14,7 @@ import { ModSimController } from "./modSimController.js";
 import { sharedDeviceCapturePipeline } from "../capture/deviceCapturePipeline.js";
 import { sharedTextToSpeechService } from "./tts/textToSpeechService.js";
 import { VisionPollingService } from "./visionPollingService.js";
+import { systemPromptForPayload } from "../llm/realInferenceProvider.js";
 
 export function explainInferenceFailure(reason: string): string {
   if (reason.includes("Unexpected end of JSON input")) {
@@ -321,7 +322,7 @@ export class SimulationOrchestrator {
       if (this.audioState.canListenToMic()) {
         sharedSttEngine.resume();
         const payload = buildPromptPayload(config, context);
-        payload.systemPrompt = this.modSim.generatePrompt(payload);
+        payload.systemPrompt = `${this.modSim.generatePrompt(payload)} ${systemPromptForPayload(payload)}`;
         let messages: ChatMessage[] = [];
 
         const inferenceStarted = Date.now();


### PR DESCRIPTION
### Motivation

- ModSim was replacing the entire system prompt each tick with a clinical template and thereby losing the higher-priority, safety/style rules from the canonical prompt (the “Masterful” rule-stack). 
- The intent is to preserve ModSim's dynamic context (vibe/intent/fishing/vision etc.) while always enforcing the global handbook rules so the model never escapes the desired behavior constraints.

### Description

- Exported `systemPromptForPayload` from `src/llm/realInferenceProvider.ts` so the orchestrator can reuse the canonical master rule-stack. 
- Refactored `ModSimController.generatePrompt` in `src/services/modSimController.ts` to emit only the per-tick dynamic “daily briefing” context (topic, transcript tail, vision/vibe/intent, behavioral/fishing directives and banned-term note). 
- Updated `SimulationOrchestrator` in `src/services/simulationOrchestrator.ts` to compose the final system prompt by concatenating `this.modSim.generatePrompt(payload)` followed by `systemPromptForPayload(payload)`, implementing the Wrapper approach.

### Testing

- Ran build with `npm run build`, which completed successfully. 
- Ran the focused test suite with `npm test -- tests/integrationRouting.test.ts tests/modSimController.test.ts tests/antiEcho.test.ts`, where `tests/integrationRouting.test.ts` and `tests/modSimController.test.ts` passed and one assertion failed in `tests/antiEcho.test.ts`. 
- Re-ran the failing test alone with `npm test -- tests/antiEcho.test.ts`, which reproduced the single failing assertion (`enforces starter diversity and brevity ratio across batches` expecting a short count >= 4 but observed 0).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc3bba096483268cd6b5ff0544ee34)