### PR TITLE
Append system prompt per-payload, simplify mod-sim prompt, and switch default cloud model to gpt-5.4-nano

### DIFF
--- a/src/config/runtimeConfig.ts
+++ b/src/config/runtimeConfig.ts
@@ -37,7 +37,7 @@ export const defaultConfig: SimulationConfig = {
     localEndpoint: "http://127.0.0.1:11434",
     localModel: "llama3.1:8b-instruct-q4_K_M",
     cloudEndpoint: "https://api.openai.com/v1/chat/completions",
-    cloudModel: "gpt-5.4-mini-2026-03-17",
+    cloudModel: "gpt-5.4-nano-2026-03-17",
     requestTimeoutMs: 30000,
     maxRetries: 1
   },

--- a/src/llm/realInferenceProvider.ts
+++ b/src/llm/realInferenceProvider.ts
@@ -155,7 +155,7 @@ function extractProviderTextOrThrow(data: ProviderResponseShape, providerLabel: 
   throw new Error(`Provider returned empty content (${providerLabel})`);
 }
 
-function systemPromptForPayload(payload: PromptPayload): string {
+export function systemPromptForPayload(payload: PromptPayload): string {
   const transcript = payload.context.transcript.trim();
   const rawTranscriptTail = transcript.slice(-230);
   const transcriptTail = rawTranscriptTail.includes(" ")

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -94,7 +94,7 @@
               <label>Local endpoint <input id="localEndpoint" type="text" value="http://127.0.0.1:11434" /></label>
               <label>Local model <input id="localModel" type="text" value="llama3.1:8b-instruct-q4_K_M" /></label>
               <label>Cloud endpoint <input id="cloudEndpoint" type="text" value="https://api.openai.com/v1/chat/completions" /></label>
-              <label>Cloud model <input id="cloudModel" type="text" value="gpt-5.4-mini-2026-03-17" /></label>
+              <label>Cloud model <input id="cloudModel" type="text" value="gpt-5.4-nano-2026-03-17" /></label>
               <label>Request timeout ms <input id="requestTimeoutMs" type="number" min="1000" max="120000" value="30000" /></label>
               <label>Max retries <input id="maxRetries" type="number" min="0" max="5" value="1" /></label>
               <label><input id="ttsEnabled" type="checkbox" checked /> TTS Enabled</label>

--- a/src/services/modSimController.ts
+++ b/src/services/modSimController.ts
@@ -79,25 +79,19 @@ export class ModSimController {
       : "No banned slang this tick.";
 
     return [
-      `Return strict JSON only: {"messages":[{"text":"string","emotes":["string"],"donationCents":number|null,"ttsText":string|null}]}.`,
-      `messages must contain exactly ${payload.requestedMessageCount} entries.`,
-      "Each message text MUST be under 10 words. Quality over quantity.",
+      "Daily briefing (dynamic context follows; global handbook rules are appended after this block).",
       `Topic lock: ${streamTopic}.`,
       transcript
-        ? `Highest priority: react to latest streamer words: "${transcriptTail}".`
+        ? `Latest streamer tail: "${transcriptTail}".`
         : "Streamer is currently quiet; continue ongoing topic naturally.",
-      `Visual grounding (internal only): ${payload.context.visionTags.length ? payload.context.visionTags.join(", ") : "none"}. React like a participant and never narrate these tags verbatim.`,
+      `Visual grounding (internal only): ${payload.context.visionTags.length ? payload.context.visionTags.join(", ") : "none"}.`,
       `Vibe=${payload.context.vibe ?? "unknown"}; Intent=${payload.context.intent ?? "none"}; Command=${Boolean(payload.context.isCommand)}.`,
       `Behavioral modes: ${payload.behavioralModes.join(", ")}.`,
       `Fishing state: ${fishingState}.`,
       primacyDirective,
       chaosDirective,
       degeneracyDirective,
-      "DO NOT mirror the streamer's opening phrase; never start with the transcript's last 2 words.",
-      bannedTermDirective,
-      "Never say: 'the viewer says', 'I am an AI', or explain system internals.",
-      "Participant-only voice: react to the streamer in first person, never as a play-by-play commentator.",
-      "Keep messages short and non-repetitive."
+      bannedTermDirective
     ].join(" ");
   }
 

--- a/src/services/simulationOrchestrator.ts
+++ b/src/services/simulationOrchestrator.ts
@@ -14,6 +14,7 @@ import { ModSimController } from "./modSimController.js";
 import { sharedDeviceCapturePipeline } from "../capture/deviceCapturePipeline.js";
 import { sharedTextToSpeechService } from "./tts/textToSpeechService.js";
 import { VisionPollingService } from "./visionPollingService.js";
+import { systemPromptForPayload } from "../llm/realInferenceProvider.js";
 
 export function explainInferenceFailure(reason: string): string {
   if (reason.includes("Unexpected end of JSON input")) {
@@ -279,8 +280,6 @@ export class SimulationOrchestrator {
       const captureProvider = createCaptureProvider(config);
       const provider = createInferenceProvider(config.inferenceMode);
       const startedAt = Date.now();
-      await this.visionService.awaitLatestPoll();
-
       if (!config.compliance.eulaAccepted) {
         this.emitMeta({ warning: "EULA must be accepted before simulation starts." });
         this.running = false;
@@ -321,7 +320,7 @@ export class SimulationOrchestrator {
       if (this.audioState.canListenToMic()) {
         sharedSttEngine.resume();
         const payload = buildPromptPayload(config, context);
-        payload.systemPrompt = this.modSim.generatePrompt(payload);
+        payload.systemPrompt = `${this.modSim.generatePrompt(payload)} ${systemPromptForPayload(payload)}`;
         let messages: ChatMessage[] = [];
 
         const inferenceStarted = Date.now();


### PR DESCRIPTION
### Motivation

- Add a concise, generated system-level prompt to each inference payload to provide extra situational grounding and vision/audio directives for the model.
- Make the `systemPromptForPayload` helper available to the orchestrator by exporting it from the LLM layer.
- Simplify and change the tone of the moderator/simulation prompt generation to a new briefing-style prompt that relaxes prior strict JSON/formatting constraints.
- Use a smaller default cloud model in config/UI by switching to `gpt-5.4-nano-2026-03-17`.

### Description

- Exported `systemPromptForPayload` from `src/llm/realInferenceProvider.ts` so it can be reused outside the file.  
- Appended the generated system prompt to the mod-sim prompt in `src/services/simulationOrchestrator.ts` via `payload.systemPrompt = `${this.modSim.generatePrompt(payload)} ${systemPromptForPayload(payload)}`;` and removed the prior `await this.visionService.awaitLatestPoll();` call before capture.  
- Rewrote `ModSimController.generatePrompt` in `src/services/modSimController.ts` to produce a compact "Daily briefing" style prompt and removed the earlier strict JSON enforcement and several previous constraints.  
- Changed the default `cloudModel` to `gpt-5.4-nano-2026-03-17` in `src/config/runtimeConfig.ts` and updated the default value shown in `src/public/index.html`.

### Testing

- Ran `npm run build` and TypeScript compilation, and the project compiled successfully.  
- Executed unit tests via `npm test`, and all tests passed.  
- Ran `npm run lint` for static checks, and linting completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc3bba096483268cd6b5ff0544ee34)