### PR TITLE
Add varied disagree openers to mock audience generator

### DIFF
--- a/src/llm/mockAudienceGenerator.ts
+++ b/src/llm/mockAudienceGenerator.ts
@@ -111,6 +111,7 @@ const memes = [
   "we are farming clips"
 ];
 const emotePool = ["🔥", "😂", "👏", "W", "LUL", "Kappa", "PogChamp", "monkaS", "OMEGALUL", "L"];
+const disagreeOpeners = ["nah", "cap", "counterpoint", "idk", "nope", "wildtake"];
 
 function pick<T>(arr: T[]): T {
   return arr[Math.floor(Math.random() * arr.length)];
@@ -132,7 +133,7 @@ function personaPool(persona: PersonaMode): string[] {
 function withBias(text: string, bias: BiasMode, conditioning: ProviderConditioning, contrarianism: number): string {
   const disagreeWeight = Math.min(0.95, 0.25 + conditioning.volatility * 0.35 + contrarianism * 0.4);
   if (bias === "agree") return conditioning.expressiveness > 0.7 ? `${text} FRFR` : `${text} fr`;
-  if (bias === "disagree") return `nah ${text.toLowerCase()}`;
+  if (bias === "disagree") return `${pick(disagreeOpeners)} ${text.toLowerCase()}`;
   if (Math.random() < disagreeWeight) return `counterpoint: ${text.toLowerCase()}`;
   return `${text} agree`;
 }


### PR DESCRIPTION
### Motivation
- Replace the single hardcoded disagree prefix with a set of openers to make contrarian chat lines more varied and realistic in `withBias`.

### Description
- Add a `disagreeOpeners` array and update `withBias` so `bias === "disagree"` returns a random opener from `disagreeOpeners` instead of always using `"nah"`.

### Testing
- Ran unit tests with `yarn test`, TypeScript checks with `tsc --noEmit`, and linting with `yarn lint`, and all automated checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc47b936a48326843f3162ee4b7df3)