### PR TITLE
UI: tighten action hierarchy, surface system utilities, and add motion/anticipation polish

### DIFF
--- a/src/public/app.js
+++ b/src/public/app.js
@@ -33,6 +33,7 @@ const triggerTestDonationBtn = document.getElementById("triggerTestDonation");
 const simulateViewerSpikeBtn = document.getElementById("simulateViewerSpike");
 const liveFrame = document.getElementById("liveFrame");
 const liveBadge = document.getElementById("liveBadge");
+const overlayEl = document.getElementById("overlay");
 
 let liveMonitorStream = null;
 let liveMonitorAudioContext = null;
@@ -220,6 +221,11 @@ function arrayBufferToBase64(buffer) {
 
 function wait(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function withEventDelay(min = 200, max = 500) {
+  const ms = Math.round(min + Math.random() * Math.max(0, max - min));
+  await wait(ms);
 }
 
 async function confirmCameraFrames(stream) {
@@ -526,16 +532,19 @@ function setSimulationActionPending(isPending) {
 
 function setSystemStateBadge(payload = latestStatusPayload) {
   if (!systemStateBadge) return;
-  let state = "idle";
+  let state = "IDLE";
+  let stateClass = "idle";
   if (simulationActionInFlight || payload?.ai?.state === "running") {
-    state = "running";
+    state = "LIVE";
+    stateClass = "running";
   }
   if (String(statusBanner?.className || "").includes("error")) {
-    state = "error";
+    state = "STOPPED";
+    stateClass = "error";
   }
-  systemStateBadge.textContent = state.charAt(0).toUpperCase() + state.slice(1);
+  systemStateBadge.textContent = state;
   systemStateBadge.classList.remove("idle", "running", "error");
-  systemStateBadge.classList.add(state);
+  systemStateBadge.classList.add(stateClass);
 }
 
 async function runAction({ button, pendingText, successText, onRun }) {
@@ -1421,6 +1430,7 @@ function renderIncomingMessages(messages) {
   messages.forEach((msg) => {
     const item = document.createElement("div");
     item.className = "chat-msg";
+    item.style.animationDelay = `${Math.round(40 + Math.random() * 160)}ms`;
 
     const user = document.createElement("span");
     user.className = "user";
@@ -1444,7 +1454,9 @@ function renderIncomingMessages(messages) {
       donation.className = "donation";
       donation.textContent = `$${(msg.donationCents / 100).toFixed(2)}`;
       item.append(donation);
+      item.classList.add("is-donation", "is-event");
     }
+    if (msg.source === "system") item.classList.add("is-event");
 
     chatEl.prepend(item);
     while (chatEl.children.length > 22) chatEl.lastChild.remove();
@@ -1478,22 +1490,36 @@ events.addEventListener("meta", (event) => {
 });
 
 sendTestChatBtn?.addEventListener("click", () => {
-  renderIncomingMessages([{ username: "test_user", text: "This is a test chat message", emotes: [], source: "test" }]);
+  void (async () => {
+    await withEventDelay();
+    renderIncomingMessages([{ username: "test_user", text: "This is a test chat message", emotes: [], source: "test" }]);
+  })();
 });
 
 triggerTestDonationBtn?.addEventListener("click", () => {
-  previewAlertCount += 1;
-  if (previewAlerts) previewAlerts.textContent = `🔔 ${previewAlertCount}`;
-  renderIncomingMessages([{ username: "donor42", text: "Great stream!", donationCents: 500, emotes: [], source: "test" }]);
+  void (async () => {
+    await withEventDelay();
+    previewAlertCount += 1;
+    if (previewAlerts) previewAlerts.textContent = `🔔 ${previewAlertCount}`;
+    overlayEl?.classList.add("event-pulse");
+    setTimeout(() => overlayEl?.classList.remove("event-pulse"), 520);
+    renderIncomingMessages([{ username: "donor42", text: "Great stream!", donationCents: 500, emotes: [], source: "test" }]);
+  })();
 });
 
 simulateViewerSpikeBtn?.addEventListener("click", () => {
-  const current = Number(controls.viewerCount.value);
-  const boosted = Math.min(5000, current + 250);
-  controls.viewerCount.value = String(boosted);
-  updateRangeLabels();
-  if (previewViewerCount) previewViewerCount.textContent = `👥 ${boosted}`;
-  addLog("system", "event", `Viewer spike simulated to ${boosted}`);
+  void (async () => {
+    await withEventDelay();
+    const current = Number(controls.viewerCount.value);
+    const boosted = Math.min(5000, current + 250);
+    controls.viewerCount.value = String(boosted);
+    updateRangeLabels();
+    if (previewViewerCount) previewViewerCount.textContent = `👥 ${boosted}`;
+    overlayEl?.classList.add("event-pulse");
+    setTimeout(() => overlayEl?.classList.remove("event-pulse"), 520);
+    renderIncomingMessages([{ username: "system", text: `Viewer spike detected: +${boosted - current}`, emotes: [], source: "system" }]);
+    addLog("system", "event", `Viewer spike simulated to ${boosted}`);
+  })();
 });
 
 async function boot() {

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>StreamSim Control Center</title>
+    <title>StreamSim Simulation Instrument</title>
     <link rel="stylesheet" href="/styles.css" />
   </head>
   <body>
@@ -21,32 +21,27 @@
                 <option value="developer">Developer</option>
               </select>
             </label>
-            <span id="systemStateBadge" class="state-pill idle">Idle</span>
+            <span id="systemStateBadge" class="state-pill idle">IDLE</span>
           </div>
         </header>
 
         <div class="workflow-stack">
-          <details class="control-group workflow-section" id="sectionSetup" open>
-            <summary><span>1. Setup</span><span id="onboardingPill" class="pill pending">Pending</span></summary>
-            <section class="onboarding-panel" id="onboardingPanel">
-              <ol class="onboarding-steps">
-                <li>Choose provider mode and stream profile.</li>
-                <li>Run readiness + performance checks.</li>
-                <li>Accept EULA to unlock simulation start.</li>
-              </ol>
-              <div class="wizard-inline-controls">
-                <label class="eula"><input id="wizardEulaAccepted" type="checkbox" /> I accept the simulation EULA/compliance terms</label>
-                <div class="buttons">
-                  <button id="runReadiness" type="button">Run Readiness</button>
-                  <button id="completeWizard" type="button" class="primary">Complete onboarding</button>
-                </div>
-                <ul id="readinessList"></ul>
-              </div>
-            </section>
-          </details>
+          <section class="control-group sticky-run workflow-section" id="sectionRun" open>
+            <div class="run-header">
+              <h3>Primary Actions</h3>
+              <span class="pill neutral">Play</span>
+            </div>
+            <div class="buttons sticky-actions">
+              <button id="start" type="button" class="primary">Start Simulation</button>
+              <button id="stop" type="button">Stop</button>
+              <button id="triggerTestDonation" type="button">Trigger Donation</button>
+              <button id="simulateViewerSpike" type="button">Simulate Spike</button>
+            </div>
+            <p id="statusBanner" class="status-banner" aria-live="polite">Ready.</p>
+          </section>
 
           <details class="control-group workflow-section" id="sectionConfigure" open>
-            <summary><span>2. Configure</span><span class="pill neutral">Profile</span></summary>
+            <summary><span>Core Controls</span><span class="pill neutral">Profile</span></summary>
             <div class="grid compact-grid">
               <label>Viewer Count
                 <input id="viewerCount" type="range" min="1" max="5000" value="100" />
@@ -60,6 +55,10 @@
                 <input id="donationFrequency" type="range" min="0" max="1" step="0.01" value="0.08" />
                 <span class="range-value" id="donationFrequencyValue">0.08</span>
               </label>
+            </div>
+            <details class="advanced-controls">
+              <summary><span>Advanced</span><span class="pill neutral">Collapsed</span></summary>
+              <div class="grid compact-grid">
               <label>Persona
                 <select id="persona">
                   <option value="supportive">Supportive</option>
@@ -85,12 +84,41 @@
                   <option value="groq">Groq</option>
                 </select>
               </label>
-            </div>
+              </div>
+            </details>
           </details>
 
-          <details class="control-group workflow-section" id="sectionConnect">
-            <summary><span>3. Connect</span><span id="connectStatusPill" class="pill neutral">Partial</span></summary>
-            <div class="grid">
+          <details class="control-group workflow-section system-status-group" id="sectionSystemStatus">
+            <summary><span>System Status</span><span id="connectStatusPill" class="pill neutral">Partial</span></summary>
+            <div class="buttons utility-actions">
+              <button id="save" type="button">Save Config</button>
+              <button id="refreshStatus" type="button">Refresh Status</button>
+              <button id="verifyMic" type="button">Verify Microphone</button>
+              <button id="verifyCamera" type="button" disabled>Verify Camera</button>
+              <button id="openOverlayWindow" type="button">Open Transparent Chat Window</button>
+            </div>
+            <details class="workflow-subsection" id="sectionSetup" open>
+              <summary><span>Setup</span><span id="onboardingPill" class="pill pending">Pending</span></summary>
+              <section class="onboarding-panel" id="onboardingPanel">
+                <ol class="onboarding-steps">
+                  <li>Choose provider mode and stream profile.</li>
+                  <li>Run readiness + performance checks.</li>
+                  <li>Accept EULA to unlock simulation start.</li>
+                </ol>
+                <div class="wizard-inline-controls">
+                  <label class="eula"><input id="wizardEulaAccepted" type="checkbox" /> I accept the simulation EULA/compliance terms</label>
+                  <div class="buttons">
+                    <button id="runReadiness" type="button">Run Readiness</button>
+                    <button id="completeWizard" type="button" class="primary">Complete onboarding</button>
+                  </div>
+                  <ul id="readinessList"></ul>
+                </div>
+              </section>
+            </details>
+
+            <details class="workflow-subsection" id="sectionConnect">
+              <summary><span>Connect</span><span class="pill neutral">Network</span></summary>
+              <div class="grid">
               <label>Local endpoint <input id="localEndpoint" type="text" value="http://127.0.0.1:11434" /></label>
               <label>Local model <input id="localModel" type="text" value="llama3.1:8b-instruct-q4_K_M" /></label>
               <label>Cloud endpoint <input id="cloudEndpoint" type="text" value="https://api.openai.com/v1/chat/completions" /></label>
@@ -134,11 +162,11 @@
               <label>STT endpoint <input id="sttEndpoint" type="text" value="http://127.0.0.1:7778/stt" /></label>
               <label>Vision endpoint <input id="visionEndpoint" type="text" value="http://127.0.0.1:7778/vision-tags" /></label>
               <label><input id="audioIntelligenceEnabled" type="checkbox" checked /> Audio Intelligence Enabled</label>
-            </div>
-          </details>
+              </div>
+            </details>
 
-          <details class="control-group workflow-section" id="sectionVerify" open>
-            <summary><span>4. Verify</span><span class="pill neutral">Status Cards</span></summary>
+            <details class="workflow-subsection" id="sectionVerify">
+            <summary><span>Verify</span><span class="pill neutral">Status Cards</span></summary>
             <h3>Runtime Verification</h3>
             <div id="statusCards" class="status-cards"></div>
             <label class="live-monitor-toggle"><input id="liveMonitorEnabled" type="checkbox" /> Enable live camera + voice monitor</label>
@@ -167,6 +195,7 @@
               <pre id="diagnosticsSummary"></pre>
               <pre id="meta"></pre>
             </div>
+            </details>
           </details>
 
           <details class="control-group workflow-section" id="sectionSecurity" data-mode-visible="developer">
@@ -205,22 +234,6 @@
             </div>
           </details>
 
-          <section class="control-group sticky-run workflow-section" id="sectionRun" open>
-            <div class="run-header">
-              <h3>5. Run</h3>
-              <span class="pill neutral">Action</span>
-            </div>
-            <div class="buttons sticky-actions">
-              <button id="start" type="button" class="primary">Start Simulation</button>
-              <button id="stop" type="button">Stop</button>
-              <button id="save" type="button">Save Config</button>
-              <button id="refreshStatus" type="button">Refresh Status</button>
-              <button id="verifyMic" type="button">Verify Microphone</button>
-              <button id="verifyCamera" type="button" disabled>Verify Camera</button>
-              <button id="openOverlayWindow" type="button">Open Transparent Chat Window</button>
-            </div>
-            <p id="statusBanner" class="status-banner" aria-live="polite">Ready.</p>
-          </section>
         </div>
       </section>
 
@@ -235,8 +248,6 @@
         </div>
         <div class="preview-actions">
           <button id="sendTestChat" type="button">Send Test Chat</button>
-          <button id="triggerTestDonation" type="button">Trigger Donation</button>
-          <button id="simulateViewerSpike" type="button">Simulate Viewer Spike</button>
         </div>
         <div id="chat"></div>
       </section>

--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -1,55 +1,69 @@
 :root {
   color-scheme: dark;
-  --bg: #0d1017;
-  --panel: #151a24;
-  --panel-alt: rgba(15, 20, 32, 0.8);
-  --text: #e9edf3;
-  --muted: #94a3b8;
-  --accent: #60a5fa;
-  --accent-muted: rgba(96, 165, 250, 0.18);
+  --bg: #0a0a0b;
+  --panel: #111214;
+  --elevated: #16181b;
+  --panel-alt: rgba(24, 26, 30, 0.92);
+  --text: #e8ebef;
+  --muted: #8f99a8;
+  --accent: #6197d9;
+  --accent-muted: rgba(97, 151, 217, 0.2);
   --success: #22c55e;
   --warning: #f59e0b;
   --danger: #ef4444;
-  --inactive: #64748b;
+  --inactive: #6b7280;
+  --soft-line: rgba(255, 255, 255, 0.05);
 }
 
-* { box-sizing: border-box; font-family: Inter, ui-sans-serif, system-ui; }
-body { margin: 0; background: radial-gradient(circle at top, #1a2133, var(--bg)); color: var(--text); }
-.layout { display: grid; grid-template-columns: minmax(340px, 470px) 1fr; gap: 16px; padding: 16px; min-height: 100vh; }
-.panel { border: 1px solid #2d3748; border-radius: 14px; background: var(--panel); padding: 16px; }
-.controls { display: flex; flex-direction: column; gap: 12px; max-height: calc(100vh - 32px); overflow: auto; }
+* { box-sizing: border-box; font-family: Inter, "Satoshi", ui-sans-serif, system-ui; }
+body {
+  margin: 0;
+  background: radial-gradient(circle at 80% 0%, rgba(97, 151, 217, 0.15), transparent 40%), var(--bg);
+  color: var(--text);
+  line-height: 1.45;
+}
+.layout { display: grid; grid-template-columns: minmax(320px, 410px) minmax(0, 1.35fr); gap: 24px; padding: 24px; min-height: 100vh; }
+.panel {
+  border: 1px solid var(--soft-line);
+  border-radius: 12px;
+  background: var(--panel);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.02), 0 16px 32px rgba(0, 0, 0, 0.28);
+  padding: 20px;
+}
+.controls { display: flex; flex-direction: column; gap: 16px; max-height: calc(100vh - 48px); overflow: auto; }
 
 .topbar { display: flex; justify-content: space-between; align-items: flex-start; gap: 12px; }
-.topbar h1 { margin: 0; font-size: 1.2rem; }
-.subtle { margin: 6px 0 0; color: var(--muted); font-size: 0.8rem; }
+.topbar h1 { margin: 0; font-size: 1.16rem; font-weight: 700; }
+.subtle { margin: 8px 0 0; color: var(--muted); font-size: 0.8rem; font-weight: 300; }
 .topbar-actions { display: flex; align-items: center; gap: 8px; }
 .mode-switch { display: flex; flex-direction: column; gap: 4px; font-size: 0.8rem; color: var(--muted); }
 
 .state-pill, .pill {
   border-radius: 999px;
-  border: 1px solid #475569;
-  padding: 2px 9px;
+  border: 1px solid var(--soft-line);
+  padding: 4px 10px;
   font-size: 0.7rem;
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
 .state-pill.idle { color: #cbd5e1; border-color: #475569; }
-.state-pill.running { color: #bbf7d0; border-color: #15803d; }
-.state-pill.error { color: #fecaca; border-color: #b91c1c; }
+.state-pill.running { color: #bbf7d0; border-color: #15803d; box-shadow: 0 0 14px rgba(34, 197, 94, 0.2); }
+.state-pill.error { color: #fecaca; border-color: #b91c1c; box-shadow: 0 0 14px rgba(239, 68, 68, 0.2); }
 .pill.pending { color: #fde68a; border-color: #a16207; }
 .pill.complete { color: #bbf7d0; border-color: #15803d; }
 .pill.neutral { color: #bfdbfe; border-color: #1d4ed8; }
 
 .workflow-stack { display: flex; flex-direction: column; gap: 12px; }
 .control-group {
-  border: 1px solid #2f3a4f;
-  border-radius: 10px;
-  padding: 12px;
-  background: rgba(17, 23, 34, 0.85);
+  border: 1px solid var(--soft-line);
+  border-radius: 12px;
+  padding: 16px;
+  background: linear-gradient(180deg, rgba(24, 26, 30, 0.9), rgba(17, 18, 20, 0.92));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.02);
 }
 .control-group summary {
   cursor: pointer;
-  font-weight: 700;
+  font-weight: 600;
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -58,15 +72,51 @@ body { margin: 0; background: radial-gradient(circle at top, #1a2133, var(--bg))
 }
 .control-group summary::-webkit-details-marker { display: none; }
 
-.grid { display: grid; gap: 12px; margin-top: 10px; }
+.grid { display: grid; gap: 12px; margin-top: 12px; }
 .compact-grid { grid-template-columns: 1fr; }
-label { display: flex; flex-direction: column; gap: 6px; font-size: 0.9rem; }
-input, select, button { border-radius: 8px; border: 1px solid #3f475f; background: #0f1420; color: var(--text); padding: 8px 10px; }
+label { display: flex; flex-direction: column; gap: 8px; font-size: 0.9rem; font-weight: 400; }
+input, select, button { border-radius: 8px; border: 1px solid var(--soft-line); background: #101114; color: var(--text); padding: 10px 12px; }
+input[type="range"] {
+  appearance: none;
+  height: 6px;
+  border-radius: 999px;
+  padding: 0;
+  background: linear-gradient(90deg, rgba(97, 151, 217, 0.35), rgba(255, 255, 255, 0.16));
+}
+input[type="range"]::-webkit-slider-thumb {
+  appearance: none;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #cfe5ff;
+  border: 1px solid rgba(97, 151, 217, 0.55);
+  box-shadow: 0 0 0 0 rgba(97, 151, 217, 0.45);
+  transition: box-shadow 180ms ease-out, transform 180ms ease-out;
+}
+input[type="range"]:active::-webkit-slider-thumb {
+  box-shadow: 0 0 0 8px rgba(97, 151, 217, 0.2);
+  transform: scale(1.05);
+}
 input:focus-visible, select:focus-visible, button:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
-button { cursor: pointer; transition: border-color 140ms ease, background-color 140ms ease, opacity 140ms ease; }
-button:hover { border-color: var(--accent); }
+button {
+  cursor: pointer;
+  transition: border-color 180ms ease-out, background-color 180ms ease-out, opacity 180ms ease-out, box-shadow 180ms ease-out, transform 180ms ease-out;
+  min-height: 40px;
+}
+button:hover { border-color: rgba(97, 151, 217, 0.45); box-shadow: 0 0 18px rgba(97, 151, 217, 0.18); }
+button:active { transform: scale(0.98); }
 button:disabled { opacity: 0.6; cursor: progress; }
 button.primary { background: var(--accent-muted); border-color: #3b82f6; }
+.advanced-controls { margin-top: 12px; }
+.advanced-controls .grid { margin-top: 10px; }
+.system-status-group > summary { margin-bottom: 8px; }
+.workflow-subsection {
+  border: 1px solid var(--soft-line);
+  border-radius: 10px;
+  padding: 12px;
+  margin-top: 10px;
+  background: rgba(17, 18, 20, 0.85);
+}
 
 .range-value { color: var(--muted); font-size: 0.8rem; }
 
@@ -82,6 +132,11 @@ button.primary { background: var(--accent-muted); border-color: #3b82f6; }
 .eula { padding: 8px; border: 1px solid #3f475f; border-radius: 8px; background: #10131b; }
 
 .buttons { display: flex; gap: 8px; margin-top: 8px; flex-wrap: wrap; }
+.utility-actions {
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid var(--soft-line);
+}
 .sticky-run { position: sticky; bottom: 0; z-index: 2; background: linear-gradient(180deg, rgba(21, 26, 36, 0.88), rgba(21, 26, 36, 1)); }
 .sticky-actions { margin-top: 8px; }
 .run-header { display: flex; justify-content: space-between; align-items: center; }
@@ -128,27 +183,48 @@ button.primary { background: var(--accent-muted); border-color: #3b82f6; }
 #voiceMeter { width: 100%; border-radius: 8px; border: 1px solid #334155; background: #020617; }
 #deviceChecks { margin: 8px 0 0; padding-left: 18px; font-size: 0.85rem; }
 
-.overlay { position: relative; background: transparent; border-style: dashed; backdrop-filter: blur(1px); }
-.transparent-ready { box-shadow: inset 0 0 0 1px rgba(125, 211, 252, 0.3); }
+.overlay {
+  position: relative;
+  background:
+    radial-gradient(circle at 80% 10%, rgba(97, 151, 217, 0.17), transparent 42%),
+    linear-gradient(180deg, rgba(22, 24, 27, 0.95), rgba(17, 18, 20, 0.95));
+  overflow: hidden;
+}
+.overlay::before {
+  content: "";
+  position: absolute;
+  inset: -40%;
+  background: radial-gradient(circle at center, rgba(97, 151, 217, 0.12), transparent 65%);
+  animation: ambientShift 12s ease-in-out infinite alternate;
+  pointer-events: none;
+}
+.transparent-ready { box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.03), 0 28px 44px rgba(0, 0, 0, 0.32); }
+.overlay.event-pulse { box-shadow: inset 0 0 0 1px rgba(245, 158, 11, 0.45), 0 0 28px rgba(245, 158, 11, 0.16), 0 28px 44px rgba(0, 0, 0, 0.32); }
 .watermark { position: absolute; top: 10px; right: 10px; opacity: 0.2; font-weight: 800; letter-spacing: 0.05em; }
 .preview-header { display: flex; align-items: center; justify-content: space-between; gap: 10px; }
 .preview-header h2 { margin: 0; }
 .preview-stats { display: flex; gap: 10px; color: #bfdbfe; font-size: 0.86rem; }
-.preview-actions { margin-top: 10px; display: flex; flex-wrap: wrap; gap: 8px; }
-#chat { display: flex; flex-direction: column; gap: 8px; margin-top: 12px; }
+.preview-actions { margin-top: 12px; display: flex; flex-wrap: wrap; gap: 8px; }
+#chat { display: flex; flex-direction: column; gap: 12px; margin-top: 16px; position: relative; z-index: 1; }
 .chat-msg {
   background: var(--panel-alt);
-  border: 1px solid #30384b;
-  padding: 8px 10px;
-  border-radius: 10px;
-  line-height: 1.4;
-  animation: pulseIn 280ms ease;
+  border: 1px solid var(--soft-line);
+  padding: 10px 12px;
+  border-radius: 12px;
+  line-height: 1.48;
+  animation: pulseIn 220ms ease-out both;
   display: flex;
   flex-wrap: wrap;
   align-items: baseline;
   gap: 4px;
   overflow-wrap: anywhere;
   word-break: break-word;
+}
+.chat-msg.is-event {
+  box-shadow: inset 0 0 0 1px rgba(245, 158, 11, 0.45), 0 0 18px rgba(245, 158, 11, 0.2);
+}
+.chat-msg.is-donation {
+  box-shadow: inset 0 0 0 1px rgba(34, 197, 94, 0.4), 0 0 16px rgba(34, 197, 94, 0.16);
 }
 .user { color: #7dd3fc; font-weight: 700; margin-right: 8px; }
 .chat-msg .user,
@@ -178,9 +254,18 @@ button.primary { background: var(--accent-muted); border-color: #3b82f6; }
 }
 .chat-msg:hover .source-tag { opacity: 1; color: #e2e8f0; border-color: #64748b; }
 
-pre { margin-top: 8px; background: #0c0e14; border: 1px solid #293145; border-radius: 8px; padding: 10px; font-size: 0.75rem; min-height: 80px; }
+pre {
+  margin-top: 8px;
+  background: #0c0e14;
+  border: 1px solid var(--soft-line);
+  border-radius: 8px;
+  padding: 10px;
+  font-size: 0.75rem;
+  font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  min-height: 80px;
+}
 
-.logs-drawer { position: fixed; right: 16px; bottom: 16px; width: min(620px, 90vw); }
+.logs-drawer { position: fixed; right: 16px; bottom: 16px; width: min(460px, 84vw); z-index: 4; }
 .logs-toggle { width: 100%; }
 .logs-panel { margin-top: 8px; border: 1px solid #334155; border-radius: 10px; background: #0b1220; padding: 10px; }
 .logs-panel.hidden { display: none; }
@@ -190,6 +275,7 @@ pre { margin-top: 8px; background: #0c0e14; border: 1px solid #293145; border-ra
 [data-ui-mode="operator"] [data-mode-visible="developer"] { display: none !important; }
 
 @keyframes pulseIn { from { transform: translateY(4px); opacity: 0.2; } to { transform: translateY(0); opacity: 1; } }
+@keyframes ambientShift { from { transform: translate3d(-3%, -2%, 0); opacity: 0.4; } to { transform: translate3d(3%, 2%, 0); opacity: 0.75; } }
 
 @media (max-width: 1080px) {
   .layout { grid-template-columns: 1fr; }


### PR DESCRIPTION
### Motivation
- Make the Live Preview workflow more instrument-like by keeping the sticky Primary Actions minimal and focused on run controls while preserving all existing IDs and wiring.
- Reduce visual competition in the primary control area by surfacing utility actions under a single System Status group.
- Improve perceived responsiveness and event feedback with light motion, small anticipation delays, and consistent runtime state labels without touching backend logic.

### Description
- Moved the utility controls (`Save Config`, `Refresh Status`, `Verify Microphone`, `Verify Camera`, `Open Transparent Chat Window`) out of the sticky Primary Actions area and into a `System Status` subsection in `src/public/index.html`, and reduced Primary Actions to only Start/Stop/Trigger Donation/Simulate Spike.
- Normalized the system badge text and runtime mapping to the presentation states `LIVE / IDLE / STOPPED` and updated `setSystemStateBadge` logic in `src/public/app.js` to reflect those labels without altering source state providers.
- Added lightweight interaction & motion support in `src/public/app.js`: introduced `withEventDelay`, wired small randomized animation delays for chat items, wrapped `sendTestChat`, `triggerTestDonation`, and `simulateViewerSpike` with asynchronous micro-delays, and added overlay pulse behavior for event feedback.
- Polished the visual language in `src/public/styles.css`: updated the darker layered palette and tokens, added `.utility-actions` visual separator, refined chat/message styles (event/donation highlight shadows), ambient gradient animation, slider/thumb polish, and consistent spacing/typography/radii.

### Testing
- Built the project locally with `npm run build` and the build completed successfully.
- Ran the test suite with `npm test`, which produced 115 passing tests and 1 failing test, where `tests/antiEcho.test.ts` fails an existing assertion (`shortCount >= 4`); this failure is unrelated to the UI-only changes introduced here.
- No automated visual screenshot was captured in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc5152df088326aa0fa88dd960369e)